### PR TITLE
K8S-967: Helm Tweaks

### DIFF
--- a/couchbase-operator/templates/couchbase-cluster-role.yaml
+++ b/couchbase-operator/templates/couchbase-cluster-role.yaml
@@ -19,6 +19,7 @@ rules:
   - list
   - watch
   - update
+{{- if .Values.couchbaseOperator.createCrd -}}
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -26,6 +27,7 @@ rules:
   verbs:
   - get
   - create
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/couchbase-operator/templates/couchbase-deployment.yaml
+++ b/couchbase-operator/templates/couchbase-deployment.yaml
@@ -25,6 +25,9 @@ spec:
         imagePullPolicy: {{ .Values.couchbaseOperator.imagePullPolicy}}
         command:
         - couchbase-operator
+        args:
+        - "--create-crd={{ .Values.couchbaseOperator.create-crd }}"
+        - "--pod-create-timeout={{ .Values.couchbaseOperator.pod-create-timeout }}"
   {{- range $key, $value := .Values.couchbaseOperator.commandArgs }}
         - "--{{ $key }}={{ $value }}"
   {{- end }}

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -32,10 +32,13 @@ couchbaseOperator:
   imagePullPolicy: IfNotPresent
   # imagePullSecrets is an optional list of references to secrets  to use for pulling images
   imagePullSecrets: []
+  # whether the operator should install the CRD.  Requires cluster level privileges.
+  createCrd: true
+  # period before pod creation times out.  Most of the time is usually required to pull large
+  # images from container registries on the internet.
+  podCreateTimeout: 10m
   # additional command arguments will be translated to `--key=value`
-  commandArgs:
-    # Set to false if you are installing the CRD manually
-    create-crd: true
+  commandArgs: []
   # readinessProbe marks pod as ready when readiness port (8080) responds
   readinessProbe:
     # initialDelaySeconds is a delay before readiness probe is initiated


### PR DESCRIPTION
Makes CRD RBAC rules conditional based on configuration and also allows
time outs to be more easily configured.