### PR TITLE
Add serviceAnnotations as variable to couchbase-cluster

### DIFF
--- a/couchbase-operator/templates/couchbase-cluster.yaml
+++ b/couchbase-operator/templates/couchbase-cluster.yaml
@@ -39,6 +39,12 @@ spec:
     dns:
       domain: {{ .Values.cluster.networking.dns.domain }}
 {{- end }}
+{{- if .Values.cluster.networking.serviceAnnotations }}
+    serviceAnnotations:
+      {{- range $key, $val := .Values.cluster.networking.serviceAnnotations }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
+{{- end }}
 {{- if (include "couchbase-cluster.tls.enabled" .) }}
     tls:
       static:

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -119,6 +119,8 @@ cluster:
     exposedFeatureServiceType: NodePort
     # The dynamic DNS configuration to use when exposing services
     dns:
+    # Custom map of annotations to be added to console and per-pod (exposed feature) services
+    serviceAnnotations: {}
     # The Couchbase cluster tls configuration (auto-generated)
     tls:
   # The retention period that log volumes are kept for after their associated pods have been deleted.


### PR DESCRIPTION
Makes using serviceAnnotations on couchbase-cluster possible from helm chart.

We have a use case where we are deploying couchbase on GKE with adminConsoleServiceType as LoadBalancer with dns. As we want to use from internal network only, for services not to get public IPs serviceAnnotation _cloud.google.com/load-balancer-type: "Internal"_ is needed.

As [this is possible](https://docs.couchbase.com/operator/current/reference-couchbasecluster.html) when configuring service with k8s yaml it would be great to have this feature available through helm too.

If this can be achieved through some other way can you please point me in the right direction 