### PR TITLE
fix: bucket naming to support underscores

### DIFF
--- a/couchbase-operator/Chart.yaml
+++ b/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.0.1
 type: application
 keywords:

--- a/couchbase-operator/Chart.yaml
+++ b/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.0.2
+version: 2.0.1
 appVersion: 2.0.1
 type: application
 keywords:

--- a/couchbase-operator/templates/couchbase-bucket.yaml
+++ b/couchbase-operator/templates/couchbase-bucket.yaml
@@ -13,9 +13,6 @@ items:
     labels:
       cluster: {{ include "couchbase-cluster.clustername" $rootScope }}
   spec:
-{{- if $spec.name }}
-    name: {{ $spec.name }}
-{{- end }}
 {{ toYaml $spec | indent 4 }}
 {{- end }}
 {{- end }}

--- a/couchbase-operator/templates/couchbase-bucket.yaml
+++ b/couchbase-operator/templates/couchbase-bucket.yaml
@@ -9,10 +9,13 @@ items:
 - apiVersion: couchbase.com/v2
   kind: CouchbaseBucket
   metadata:
-    name: {{ default $bucket $spec.name }}
+    name: {{ default $bucket }}
     labels:
       cluster: {{ include "couchbase-cluster.clustername" $rootScope }}
   spec:
+{{- if $spec.name }}
+    name: {{ $spec.name }}
+{{- end }}
 {{ toYaml $spec | indent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
If merged, this PR will::

- Update `couchbase-bucket.yaml` to populate `spec.name` (AO 2.0.1 will use this over `metadata.name`)
- Resolve https://issues.couchbase.com/browse/K8S-1547