### PR TITLE
Add Networking Traffic Policy

### DIFF
--- a/couchbase-operator/templates/couchbase-cluster.yaml
+++ b/couchbase-operator/templates/couchbase-cluster.yaml
@@ -36,6 +36,7 @@ spec:
     {{- end }}
     adminConsoleServiceType: {{ .Values.cluster.networking.adminConsoleServiceType }}
     exposedFeatureServiceType: {{ .Values.cluster.networking.exposedFeatureServiceType }}
+    exposedFeatureTrafficPolicy: {{ .Values.cluster.networking.exposedFeatureTrafficPolicy }}
 {{- if .Values.cluster.networking.dns }}
     dns:
       domain: {{ .Values.cluster.networking.dns.domain }}

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -119,6 +119,8 @@ cluster:
     # Allowed values are NodePort and LoadBalancer.
     # If this field is LoadBalancer then you must also define a spec.dns.domain.
     exposedFeatureServiceType: NodePort
+    # This controls routing to external services.
+    exposedFeatureTrafficPolicy: Local
     # The dynamic DNS configuration to use when exposing services
     dns:
     # Custom map of annotations to be added to console and per-pod (exposed feature) services


### PR DESCRIPTION
This functionality is defined by the CouchbaseCluster but not exposed by
the Helm chart, and needs to be for some deployments.