### PR TITLE
Add support for additional Sync Gateway manifest configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/values.local*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/values.local*.yaml
+**/*.log

--- a/couchbase-operator/Chart.yaml
+++ b/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.1.006
+version: 2.1.007
 appVersion: 2.1.0
 type: application
 keywords:

--- a/couchbase-operator/Chart.yaml
+++ b/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.1.007
+version: 2.1.008
 appVersion: 2.1.0
 type: application
 keywords:

--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -5,10 +5,13 @@ kind: Deployment
 metadata:
   name: {{ include "couchbase-cluster.sg.name" . }}
   labels:
+    {{- with .Values.syncGateway.lLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}    
 spec:
   replicas: {{ .Values.syncGateway.replicas }}
   selector:
@@ -17,8 +20,23 @@ spec:
   template:
     metadata:
       labels:
+        {{- with .Values.syncGateway.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/name: {{ template "couchbase-cluster.sg.name" . }}
     spec:
+      {{- with .Values.syncGateway.affinity }}
+      affinity:        
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.syncGateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.syncGateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
       containers:
       - name: sync-gateway
         image: "{{ .Values.syncGateway.image.repository }}:{{ .Values.syncGateway.image.tag }}"
@@ -30,6 +48,25 @@ spec:
         env:
         - name: GOMAXPROCS
           value: "1"
+        ports:
+          - containerPort: 4984
+            name: public
+          {{- if .Values.syncGateway.admin.enabled }}
+          - containerPort: 4985
+            name: admin
+          {{- end }}
+        resources:          
+{{ toYaml .Values.syncGateway.resources | indent 10 }}
+      {{- if .Values.syncGateway.monitoring.prometheus.enabled }}
+      - name: exporter
+        image: {{ default "couchbasesamples/sync-gateway-prometheus-exporter:latest" .Values.syncGateway.monitoring.prometheus.image }}
+        args: ["--log.level={{ default "info" .Values.syncGateway.monitoring.prometheus.logLevel }}"]
+        ports:
+        - name: http
+          containerPort: 9421
+        resources:
+{{ toYaml .Values.syncGateway.monitoring.prometheus.resources | indent 10 }}          
+      {{- end }}
       volumes:
       - name: config
         secret:
@@ -44,7 +81,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
+  creationTimestamp: null  
+  {{- with .Values.syncGateway.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -53,9 +94,16 @@ metadata:
   name: {{ include "couchbase-cluster.sg.name" . }}
 spec:
   ports:
-  - port: 4984
+  - name: public
+    port: 4984
     protocol: TCP
     targetPort: 4984
+  {{- if .Values.syncGateway.admin.enabled }}
+  - name: admin
+    port: 4985
+    protocol: TCP
+    targetPort: 4985  
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
   type: ClusterIP
@@ -65,6 +113,10 @@ apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
+  {{- with .Values.syncGateway.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}  
   labels:
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -77,6 +129,12 @@ spec:
   - port: 4984
     protocol: TCP
     targetPort: 4984
+  {{- if .Values.syncGateway.admin.enabled }}
+  - name: admin
+    port: 4985
+    protocol: TCP
+    targetPort: 4985  
+  {{- end }}    
   selector:
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
   sessionAffinity: None
@@ -89,6 +147,9 @@ metadata:
   annotations:
 {{- if .Values.cluster.networking.dns }}
     external-dns.alpha.kubernetes.io/hostname: {{ include "couchbase-cluster.sg.externalname" . }}
+{{- end }}
+{{- if .Values.syncGateway.service.annotations }}
+{{ toYaml .Values.syncGateway.service.annotations | indent 4 }}
 {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
@@ -103,6 +164,12 @@ spec:
     port: 4984
     protocol: TCP
     targetPort: 4984
+  {{- if .Values.syncGateway.admin.enabled }}
+  - name: admin
+    port: 4985
+    protocol: TCP
+    targetPort: 4985  
+  {{- end }}    
   selector:
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
   sessionAffinity: None

--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -14,6 +14,9 @@ metadata:
     helm.sh/chart: {{ include "couchbase-cluster.chart" . }}    
 spec:
   replicas: {{ .Values.syncGateway.replicas }}
+  {{- with .Values.syncGateway.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "couchbase-cluster.sg.name" . }}

--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}      
       containers:
       - name: sync-gateway
-        image: "{{ .Values.syncGateway.image.repository }}:{{ .Values.syncGateway.image.tag }}"
+        image: {{ (printf "%s:%s" .Values.syncGateway.image.repository .Values.syncGateway.image.tag) | quote }}
         imagePullPolicy: {{ .Values.syncGateway.imagePullPolicy }}
         volumeMounts:
         - mountPath: /etc/sync_gateway
@@ -62,7 +62,7 @@ spec:
 {{ toYaml .Values.syncGateway.resources | indent 10 }}
       {{- if .Values.syncGateway.monitoring.prometheus.enabled }}
       - name: exporter
-        image: "{{ .Values.syncGateway.monitoring.prometheus.image.repository }}:{{ .Values.syncGateway.monitoring.prometheus.image.tag }}"
+        image: {{ (printf "%s:%s" .Values.syncGateway.monitoring.prometheus.image.repository .Values.syncGateway.monitoring.prometheus.image.tag) | quote }}
         args: ["--log.level={{ default "info" .Values.syncGateway.monitoring.prometheus.logLevel }}"]
         ports:
         - name: http

--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -127,7 +127,7 @@ metadata:
     helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
   name: {{ include "couchbase-cluster.sg.name" . }}
 spec:
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: {{ default "Cluster" .Values.syncGateway.service.externalTrafficPolicy }}
   ports:
   - port: 4984
     protocol: TCP
@@ -161,7 +161,7 @@ metadata:
     helm.sh/chart: {{ include "couchbase-cluster.chart" . }}
   name: {{ include "couchbase-cluster.sg.name" . }}
 spec:
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ default "Local" .Values.syncGateway.service.externalTrafficPolicy }}
   ports:
   - name: sync-gateway-admin
     port: 4984
@@ -178,4 +178,25 @@ spec:
   sessionAffinity: None
   type: LoadBalancer
 {{- end -}}
+{{- if .Values.syncGateway.monitoring.prometheus.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sync-gateway-exporter
+  labels:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-cluster.chart" . }}   
+spec:
+  ports:
+    - port: 9421
+      protocol: TCP
+      targetPort: http
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}
+  type: ClusterIP
+{{- end -}}  
 {{- end -}}

--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -62,7 +62,7 @@ spec:
 {{ toYaml .Values.syncGateway.resources | indent 10 }}
       {{- if .Values.syncGateway.monitoring.prometheus.enabled }}
       - name: exporter
-        image: {{ default "couchbasesamples/sync-gateway-prometheus-exporter:latest" .Values.syncGateway.monitoring.prometheus.image }}
+        image: "{{ .Values.syncGateway.monitoring.prometheus.image.repository }}:{{ .Values.syncGateway.monitoring.prometheus.image.tag }}"
         args: ["--log.level={{ default "info" .Values.syncGateway.monitoring.prometheus.logLevel }}"]
         ports:
         - name: http

--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: {{ include "couchbase-cluster.sg.name" . }}
   labels:
-    {{- with .Values.syncGateway.lLabels }}
+    {{- with .Values.syncGateway.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     app.kubernetes.io/name: {{ include "couchbase-cluster.sg.name" . }}

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -382,6 +382,8 @@ syncGateway:
   service:
     # additional annotations to add to the Sync Gateway service. useful for setting cloud provider specific annotations controlling the services deployed.
     annotations: {}
+    # optionally configure traffic policy for LoadBalancer and NodePort
+    externalTrafficPolicy:
   # defines integration with third party monitoring sofware
   monitoring:
     prometheus:

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -362,6 +362,7 @@ syncGateway:
   # how many sync gateway pods to create
   # horizontally scale the deployment
   replicas: 1
+  # optional set to change cleanup policy
   revisionHistoryLimit:
   # labels to apply to the deployment resource
   labels: {}
@@ -374,12 +375,12 @@ syncGateway:
   # which nodes to run the pods on
   nodeSelector: {}
   # tolerations to apply to the pods
-  tolerations: []
-  # defines if the admin api will be exposed by sync gateway
+  tolerations: []  
   admin:
-    enabled: false
-  # additional annotations to add to the Sync Gateway service. useful for setting cloud provider specific annotations controlling the services deployed.
+    # defines if the admin api will be exposed by sync gateway
+    enabled: false  
   service:
+    # additional annotations to add to the Sync Gateway service. useful for setting cloud provider specific annotations controlling the services deployed.
     annotations: {}
   # defines integration with third party monitoring sofware
   monitoring:

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -362,6 +362,7 @@ syncGateway:
   # how many sync gateway pods to create
   # horizontally scale the deployment
   replicas: 1
+  revisionHistoryLimit:
   # labels to apply to the deployment resource
   labels: {}
   # labels to apply to the pods

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -391,7 +391,9 @@ syncGateway:
       enabled: false
       # image used by the Sync Gateway to perform metric collection
       # (injected as a "sidecar" in each Sync Gateway Pod)
-      image: couchbasesamples/sync-gateway-prometheus-exporter:latest
+      image:
+        repository: couchbasesamples/sync-gateway-prometheus-exporter
+        tag: latest
       # pod
       resources: {}
         # requests:

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -362,6 +362,38 @@ syncGateway:
   # how many sync gateway pods to create
   # horizontally scale the deployment
   replicas: 1
+  # labels to apply to the deployment resource
+  labels: {}
+  # labels to apply to the pods
+  podLabels: {}
+  # resources to apply to the pods
+  resources: {}
+  # affinity to apply to the pods
+  affinity: {}
+  # which nodes to run the pods on
+  nodeSelector: {}
+  # tolerations to apply to the pods
+  tolerations: []
+  # defines if the admin api will be exposed by sync gateway
+  admin:
+    enabled: false
+  # additional annotations to add to the Sync Gateway service. useful for setting cloud provider specific annotations controlling the services deployed.
+  service:
+    annotations: {}
+  # defines integration with third party monitoring sofware
+  monitoring:
+    prometheus:
+      # defines whether Prometheus metric collection is enabled
+      enabled: false
+      # image used by the Sync Gateway to perform metric collection
+      # (injected as a "sidecar" in each Sync Gateway Pod)
+      image: couchbasesamples/sync-gateway-prometheus-exporter:latest
+      # pod
+      resources: {}
+        # requests:
+        #   cpu: 100m
+        # limits:
+        #   cpu: 100m
   # database config
   config:
     logging:


### PR DESCRIPTION
- Expose deployment and pod labels
- Expose service annotations. useful for cloud provider specific settings.
- Expose Sync Gateway Prometheus monitoring sidecar
- Expose various manifest settings around pod placement
- Expose admin endpoint configuration