### PR TITLE
Fix 2.1 CRDs

### DIFF
--- a/couchbase-operator/crds/couchbase.crds.yaml
+++ b/couchbase-operator/crds/couchbase.crds.yaml
@@ -7138,8 +7138,6 @@ spec:
                               - name
                               type: object
                             type: array
-                        required:
-                        - containers
                         type: object
                     type: object
                   resources:


### PR DESCRIPTION
We did a stealth update in early January, but needed to update Helm too,
which got forgotten about.  Add in the latest files.