### PR TITLE
Fix sync gateway port names

### DIFF
--- a/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -129,7 +129,8 @@ metadata:
 spec:
   externalTrafficPolicy: {{ default "Cluster" .Values.syncGateway.service.externalTrafficPolicy }}
   ports:
-  - port: 4984
+  - name: public
+    port: 4984
     protocol: TCP
     targetPort: 4984
   {{- if .Values.syncGateway.admin.enabled }}
@@ -163,7 +164,7 @@ metadata:
 spec:
   externalTrafficPolicy: {{ default "Local" .Values.syncGateway.service.externalTrafficPolicy }}
   ports:
-  - name: sync-gateway-admin
+  - name: public
     port: 4984
     protocol: TCP
     targetPort: 4984


### PR DESCRIPTION
Give the sync gateway service public port a name for the `NodePort` configuration, so it doesn't throw an error when enabling the admin port. Also fix the name on the public port for the `LoadBalancer` configuration.