### PR TITLE
K8S-2120: Updates to helm chart for 2.2.0 upcoming release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/values.local*.yaml
 **/*.log
+*.tgz

--- a/couchbase-operator/Chart.yaml
+++ b/couchbase-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.1.016
-appVersion: 2.1.0
+version: 2.2.0.1
+appVersion: 2.2.0
 type: application
 keywords:
 - couchbase

--- a/couchbase-operator/Chart.yaml
+++ b/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.2.0.1
+version: 2.2.001
 appVersion: 2.2.0
 type: application
 keywords:

--- a/couchbase-operator/README.md
+++ b/couchbase-operator/README.md
@@ -13,14 +13,13 @@ To quickly deploy the admission controller and Operator, as well as a
 Couchbase Server cluster:
 
 1.  Add the chart repository to `helm`:
-
+```
         helm repo add couchbase https://couchbase-partners.github.io/helm-charts/
         helm repo update
-
+```
 2.  Install the Chart:
-
-        helm install default couchbase/couchbase-operator
-
-
+```
+        helm upgrade --install default couchbase/couchbase-operator
+```
 See Couchbase Helm [Documentation](https://docs.couchbase.com/operator/current/helm-setup-guide.html)
 for more information about customizing and managing your charts.

--- a/couchbase-operator/crds/couchbase.crds.yaml
+++ b/couchbase-operator/crds/couchbase.crds.yaml
@@ -1,18 +1,11 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbaseautoscalers.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.size
-    name: size
-    type: string
-  - JSONPath: .spec.servers
-    name: servers
-    type: string
   group: couchbase.com
   names:
     kind: CouchbaseAutoscaler
@@ -22,85 +15,75 @@ spec:
     - cba
     singular: couchbaseautoscaler
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.labelSelector
-      specReplicasPath: .spec.size
-      statusReplicasPath: .status.size
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            servers:
-              minLength: 1
-              type: string
-            size:
-              minimum: 0
-              type: integer
-          required:
-          - servers
-          - size
-          type: object
-        status:
-          properties:
-            labelSelector:
-              type: string
-            size:
-              minimum: 0
-              type: integer
-          required:
-          - labelSelector
-          - size
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.size
+      name: size
+      type: string
+    - jsonPath: .spec.servers
+      name: servers
+      type: string
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: CouchbaseAutoscaler provides an interface for the Kubernetes Horizontal Pod Autoscaler to interactive with the Couchbase cluster and provide autoscaling.  This resource is not defined by the end user, and is managed by the Operator.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseAutoscalerSpec allows control over an autoscaling group.
+            properties:
+              servers:
+                description: Servers specifies the server group that this autoscaler belongs to.
+                minLength: 1
+                type: string
+              size:
+                description: Size allows the server group to be dynamically scaled.
+                minimum: 0
+                type: integer
+            required:
+            - servers
+            - size
+            type: object
+          status:
+            description: CouchbaseAutoscalerStatus provides information to the HPA to assist with scaling server groups.
+            properties:
+              labelSelector:
+                description: LabelSelector allows the HPA to select resources to monitor for resource utilization in order to trigger scaling.
+                type: string
+              size:
+                description: Size is the current size of the server group.
+                minimum: 1
+                type: integer
+            required:
+            - labelSelector
+            - size
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.size
+        statusReplicasPath: .status.size
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbasebackuprestores.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.capacityUsed
-    name: capacity used
-    type: string
-  - JSONPath: .status.lastRun
-    name: last run
-    type: string
-  - JSONPath: .status.lastSuccess
-    name: last success
-    type: string
-  - JSONPath: .status.duration
-    name: duration
-    type: string
-  - JSONPath: .status.running
-    name: running
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseBackupRestore
@@ -110,172 +93,237 @@ spec:
     - cbrestore
     singular: couchbasebackuprestore
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            backoffLimit:
-              description: Number of times the restore job should try to execute.
-              format: int32
-              type: integer
-            backup:
-              description: the cbbackup we associate this restore with or the cbbackup
-                pvc we want to restore from
-              type: string
-            end:
-              description: struct we use in CouchbaseBackupRestoreSpec to enforce
-                type-safeness
-              properties:
-                int:
-                  minimum: 1
-                  type: integer
-                str:
-                  type: string
-              type: object
-            logRetention:
-              description: Number of hours to hold restore script logs for, everything
-                older will be deleted
-              type: string
-            repo:
-              description: Repo is the backup folder to restore from
-              type: string
-            s3bucket:
-              description: Name of S3 bucket to restore from. If non-empty this overrides
-                local backup
-              type: string
-            start:
-              description: Start and End denote the names of the start and end backups
-                of a time range to restore backups from this will restore these two
-                backups and any backups in between. If we only wish to restore one
-                backup leave end blank or use the same backup for End
-              properties:
-                int:
-                  minimum: 1
-                  type: integer
-                str:
-                  type: string
-              type: object
-          required:
-          - backup
-          - start
-          type: object
-        status:
-          properties:
-            archive:
-              description: Location of Backup Archive
-              type: string
-            backups:
-              description: Backups gives us a full list of all backups and their respective
-                repo locations
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.capacityUsed
+      name: capacity used
+      type: string
+    - jsonPath: .status.lastRun
+      name: last run
+      type: string
+    - jsonPath: .status.lastSuccess
+      name: last success
+      type: string
+    - jsonPath: .status.duration
+      name: duration
+      type: string
+    - jsonPath: .status.running
+      name: running
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: CouchbaseBackupRestore allows the restoration of all Couchbase cluster data from a CouchbaseBackup resource.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseBackupRestoreSpec allows the specification of data restoration to be configured.  This includes the backup and repository to restore data from, and the time range of data to be restored.
+            properties:
+              backoffLimit:
+                default: 2
+                description: Number of times the restore job should try to execute.
+                format: int32
+                type: integer
+              backup:
+                description: The backup resource name associated with this restore, or the backup PVC we want to restore from.
+                type: string
+              buckets:
+                default: {}
+                description: Specific buckets can be explicitly included or excluded in the restore, as well as bucket mappings.
                 properties:
-                  full:
-                    description: the full backup inside the repo
-                    type: string
-                  incrementals:
-                    description: incremental backups inside the repo
+                  bucketMap:
+                    description: Maps a backup bucket to a destination bucket that has a different name than the bucket that was originally backed up. This parameter takes a list of mappings since multiple buckets may be restored at the same time. Each bucket mapping is separated by an "=" If we have two buckets, bucket-1 and bucket-2, and we want to restore them to renamed-1 and renamed-2 then we would denote the mapping as "bucket-1=renamed-1,bucket-2=renamed-2". This option will only restore data to the Data service and will not restore the metadata for any other service.
+                    items:
+                      properties:
+                        destination:
+                          description: Destination is the destination bucket name in the Couchbase cluster.
+                          type: string
+                        source:
+                          description: Source is the source bucket name in the backup.
+                          type: string
+                      required:
+                      - destination
+                      - source
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - source
+                    x-kubernetes-list-type: map
+                  exclude:
+                    description: Exclude the buckets in the following list of strings
                     items:
                       type: string
                     type: array
-                  name:
-                    description: name of the repo
-                    type: string
-                required:
-                - name
+                  include:
+                    description: Restore the buckets in the following list of strings.
+                    items:
+                      type: string
+                    type: array
                 type: object
-              type: array
-            duration:
-              description: Duration tells us how long the last restore took
-              type: string
-            failed:
-              description: Failed indicates whether the most recent restore has failed
-              type: boolean
-            job:
-              description: Job tells us which job is running/ran last
-              type: string
-            lastFailure:
-              description: LastFailure tells us the time the last failed restore failed
-              format: date-time
-              type: string
-            lastRun:
-              description: LastRun tells us the time the last restore job started
-              format: date-time
-              type: string
-            lastSuccess:
-              description: LastSuccess gives us the time the last successful restore
-                finished
-              format: date-time
-              type: string
-            output:
-              description: Output reports useful information from the backup_script
-              type: string
-            pod:
-              description: Pod tells us which pod is running/ran last
-              type: string
-            repo:
-              description: Repo is where we are currently performing operations
-              type: string
-            running:
-              description: Running indicates whether a restore is currently being
-                performed
-              type: boolean
-          required:
-          - failed
-          - job
-          - pod
-          - running
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
-  versions:
-  - name: v2
+              end:
+                description: End denotes the last backup to restore from.  Omitting this field will only restore the backup referenced by start.
+                properties:
+                  int:
+                    description: Int references a relative backup by index.
+                    minimum: 1
+                    type: integer
+                  str:
+                    description: Str references an absolute backup by name.
+                    type: string
+                type: object
+              logRetention:
+                default: 168h
+                description: Number of hours to hold restore script logs for, everything older will be deleted.
+                type: string
+              repo:
+                description: Repo is the backup folder to restore from.
+                type: string
+              s3bucket:
+                description: Name of S3 bucket to restore from. If non-empty this overrides local backup.
+                type: string
+              services:
+                default: {}
+                description: This list accepts a certain set of parameters that will disable that data and prevent it being restored.
+                properties:
+                  analytics:
+                    default: true
+                    description: Analytics maps to cbbackupmgr option --disable-analytics.
+                    type: boolean
+                  bucketConfig:
+                    description: BucketConfig maps to cbbackupmgr option --enable-bucket-config.
+                    type: boolean
+                  data:
+                    default: true
+                    description: Data maps to cbbackupmgr option --disable-data.
+                    type: boolean
+                  eventing:
+                    default: true
+                    description: Eventing maps to cbbackupmgr option --disable-eventing.
+                    type: boolean
+                  ftAlias:
+                    default: true
+                    description: FTAlias maps to cbbackupmgr option --disable-ft-alias.
+                    type: boolean
+                  ftIndex:
+                    default: true
+                    description: FTIndex maps to cbbackupmgr option --disable-ft-indexes.
+                    type: boolean
+                  gsiIndex:
+                    default: true
+                    description: GSIIndex maps to cbbackupmgr option --disable-gsi-indexes.
+                    type: boolean
+                  views:
+                    default: true
+                    description: View maps to cbbackupmgr option --disable-views.
+                    type: boolean
+                type: object
+              start:
+                description: Start denotes the first backup to restore from.
+                properties:
+                  int:
+                    description: Int references a relative backup by index.
+                    minimum: 1
+                    type: integer
+                  str:
+                    description: Str references an absolute backup by name.
+                    type: string
+                type: object
+              threads:
+                default: 1
+                description: How many threads to use during the restore.
+                minimum: 1
+                type: integer
+            required:
+            - backup
+            - start
+            type: object
+          status:
+            description: CouchbaseBackupRestoreStatus provides status indications of a restore from backup.  This includes whether or not the restore is running, whether the restore succeed or not, and the duration the restore took.
+            properties:
+              archive:
+                description: Location of Backup Archive.
+                type: string
+              backups:
+                description: Backups gives us a full list of all backups and their respective repository locations.
+                items:
+                  properties:
+                    full:
+                      description: Full backup inside the repository.
+                      type: string
+                    incrementals:
+                      description: Incremental backups inside the repository.
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name of the repository.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              duration:
+                description: Duration tells us how long the last restore took.
+                type: string
+              failed:
+                description: Failed indicates whether the most recent restore has failed.
+                type: boolean
+              job:
+                description: Job tells us which job is running/ran last.
+                type: string
+              lastFailure:
+                description: LastFailure tells us the time the last failed restore failed.
+                format: date-time
+                type: string
+              lastRun:
+                description: LastRun tells us the time the last restore job started.
+                format: date-time
+                type: string
+              lastSuccess:
+                description: LastSuccess gives us the time the last successful restore finished.
+                format: date-time
+                type: string
+              output:
+                description: Output reports useful information from the backup process.
+                type: string
+              pod:
+                description: Pod tells us which pod is running/ran last.
+                type: string
+              repo:
+                description: Repo is where we are currently performing operations.
+                type: string
+              running:
+                description: Running indicates whether a restore is currently being performed.
+                type: boolean
+            required:
+            - failed
+            - job
+            - pod
+            - running
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbasebackups.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.strategy
-    name: strategy
-    type: string
-  - JSONPath: .spec.size
-    name: volume size
-    type: string
-  - JSONPath: .status.capacityUsed
-    name: capacity used
-    type: string
-  - JSONPath: .status.lastRun
-    name: last run
-    type: string
-  - JSONPath: .status.lastSuccess
-    name: last success
-    type: string
-  - JSONPath: .status.running
-    name: running
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseBackup
@@ -285,202 +333,230 @@ spec:
     - cbbackup
     singular: couchbasebackup
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            backoffLimit:
-              description: Number of times a backup job should try to execute. Once
-                it hits the BackoffLimit it will not run until the next scheduled
-                job
-              format: int32
-              type: integer
-            backupRetention:
-              description: Number of hours to hold backups for, everything older will
-                be deleted
-              type: string
-            failedJobsHistoryLimit:
-              description: Amount of failed jobs to keep
-              format: int32
-              minimum: 0
-              type: integer
-            full:
-              description: Full is the schedule on when to take full backups. Used
-                in Full/Incremental and FullOnly backup strategies
-              properties:
-                schedule:
-                  description: Schedule takes a cron schedule in string format
-                  type: string
-              required:
-              - schedule
-              type: object
-            incremental:
-              description: Incremental is the schedule on when to take incremental
-                backups. Used in Full/Incremental backup strategies
-              properties:
-                schedule:
-                  description: Schedule takes a cron schedule in string format
-                  type: string
-              required:
-              - schedule
-              type: object
-            logRetention:
-              description: Number of hours to hold script logs for, everything older
-                will be deleted
-              type: string
-            s3bucket:
-              description: Name of S3 bucket to backup to. If non-empty this overrides
-                local backup
-              type: string
-            size:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Size in GB of the associated PVC
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            storageClassName:
-              description: Name of StorageClass to use
-              type: string
-            strategy:
-              description: 'CB backup strategy - Full/Incremental, Full only. Default:
-                Full/Incremental'
-              enum:
-              - full_incremental
-              - full_only
-              type: string
-            successfulJobsHistoryLimit:
-              description: Amount of successful jobs to keep
-              format: int32
-              minimum: 0
-              type: integer
-          required:
-          - strategy
-          type: object
-        status:
-          properties:
-            archive:
-              description: Location of Backup Archive
-              type: string
-            backups:
-              description: Backups gives us a full list of all backups and their respective
-                repo locations
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.strategy
+      name: strategy
+      type: string
+    - jsonPath: .spec.size
+      name: volume size
+      type: string
+    - jsonPath: .status.capacityUsed
+      name: capacity used
+      type: string
+    - jsonPath: .status.lastRun
+      name: last run
+      type: string
+    - jsonPath: .status.lastSuccess
+      name: last success
+      type: string
+    - jsonPath: .status.running
+      name: running
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: CouchbaseBackup allows automatic backup of all data from a Couchbase cluster into persistent storage.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseBackupSpec is allows the specification of how a Couchbase backup is configured, including when backups are performed, how long they are retained for, and where they are backed up to.
+            properties:
+              autoScaling:
+                description: AutoScaling allows the volume size to be dynamically increased. When specified, the backup volume will start with an initial size as defined by `spec.size`, and increase as required.
                 properties:
-                  full:
-                    description: the full backup inside the repo
+                  incrementPercent:
+                    default: 20
+                    description: IncrementPercent controls how much the volume is increased each time the threshold is exceeded, upto a maximum as defined by the limit. This field defaults to 20 if not specified.
+                    minimum: 0
+                    type: integer
+                  limit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Limit imposes a hard limit on the size we can autoscale to.  When not specified no bounds are imposed.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     type: string
-                  incrementals:
-                    description: incremental backups inside the repo
-                    items:
-                      type: string
-                    type: array
-                  name:
-                    description: name of the repo
+                    x-kubernetes-int-or-string: true
+                  thresholdPercent:
+                    default: 20
+                    description: ThresholdPercent determines the point at which a volume is autoscaled. This represents the percentage of free space remaining on the volume, when less than this threshold, it will trigger a volume expansion. For example, if the volume is 100Gi, and the threshold 20%, then a resize will be triggered when the used capcity exceeds 80Gi, and free space is less than 20Gi.  This field defaults to 20 if not specified.
+                    maximum: 99
+                    minimum: 0
+                    type: integer
+                type: object
+              backoffLimit:
+                default: 2
+                description: Number of times a backup job should try to execute. Once it hits the BackoffLimit it will not run until the next scheduled job.
+                format: int32
+                type: integer
+              backupRetention:
+                default: 720h
+                description: Number of hours to hold backups for, everything older will be deleted.
+                type: string
+              failedJobsHistoryLimit:
+                default: 3
+                description: Amount of failed jobs to keep.
+                format: int32
+                minimum: 0
+                type: integer
+              full:
+                description: Full is the schedule on when to take full backups. Used in Full/Incremental and FullOnly backup strategies.
+                properties:
+                  schedule:
+                    description: Schedule takes a cron schedule in string format.
                     type: string
                 required:
-                - name
+                - schedule
                 type: object
-              type: array
-            capacityUsed:
-              anyOf:
-              - type: integer
-              - type: string
-              description: CapacityUsed tells us how much of the PVC we are using
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            cronjob:
-              description: Cronjob tells us which Cronjob the job belongs to
-              type: string
-            duration:
-              description: Duration tells us how long the last backup took
-              type: string
-            failed:
-              description: Failed indicates whether the most recent backup has failed
-              type: boolean
-            job:
-              description: Job tells us which job is running/ran last
-              type: string
-            lastFailure:
-              description: LastFailure tells us the time the last failed backup failed
-              format: date-time
-              type: string
-            lastRun:
-              description: LastRun tells us the time the last backup job started
-              format: date-time
-              type: string
-            lastSuccess:
-              description: LastSuccess gives us the time the last successful backup
-                finished
-              format: date-time
-              type: string
-            output:
-              description: Output reports useful information from the backup_script
-              type: string
-            pod:
-              description: Pod tells us which pod is running/ran last
-              type: string
-            repo:
-              description: Repo is where we are currently performing operations
-              type: string
-            running:
-              description: Running indicates whether a backup is currently being performed
-              type: boolean
-          required:
-          - cronjob
-          - failed
-          - job
-          - pod
-          - running
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
-  versions:
-  - name: v2
+              incremental:
+                description: Incremental is the schedule on when to take incremental backups. Used in Full/Incremental backup strategies.
+                properties:
+                  schedule:
+                    description: Schedule takes a cron schedule in string format.
+                    type: string
+                required:
+                - schedule
+                type: object
+              logRetention:
+                default: 168h
+                description: Number of hours to hold script logs for, everything older will be deleted.
+                type: string
+              s3bucket:
+                description: Name of S3 bucket to backup to. If non-empty this overrides local backup.
+                type: string
+              size:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 20Gi
+                description: Size allows the specification of a backup persistent volume, when using volume based backup.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                type: string
+                x-kubernetes-int-or-string: true
+              storageClassName:
+                description: Name of StorageClass to use.
+                type: string
+              strategy:
+                default: full_incremental
+                description: 'CB backup strategy - Full/Incremental, Full only. Default: Full/Incremental'
+                enum:
+                - full_incremental
+                - full_only
+                type: string
+              successfulJobsHistoryLimit:
+                default: 3
+                description: Amount of successful jobs to keep.
+                format: int32
+                minimum: 0
+                type: integer
+              threads:
+                default: 1
+                description: How many threads to use during the backup.
+                minimum: 1
+                type: integer
+            required:
+            - strategy
+            type: object
+          status:
+            description: CouchbaseBackupStatus provides status notifications about the Couchbase backup including when the last backup occurred, whether is succeeded or not, the run time of the backup and the size of the backup.
+            properties:
+              archive:
+                description: Location of Backup Archive.
+                type: string
+              backups:
+                description: Backups gives us a full list of all backups and their respective repository locations.
+                items:
+                  properties:
+                    full:
+                      description: Full backup inside the repository.
+                      type: string
+                    incrementals:
+                      description: Incremental backups inside the repository.
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name of the repository.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              capacityUsed:
+                anyOf:
+                - type: integer
+                - type: string
+                description: CapacityUsed tells us how much of the PVC we are using.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                type: string
+                x-kubernetes-int-or-string: true
+              cronjob:
+                description: Cronjob tells us which Cronjob the job belongs to.
+                type: string
+              duration:
+                description: Duration tells us how long the last backup took.
+                type: string
+              failed:
+                description: Failed indicates whether the most recent backup has failed.
+                type: boolean
+              job:
+                description: Job tells us which job is running/ran last.
+                type: string
+              lastFailure:
+                description: LastFailure tells us the time the last failed backup failed.
+                format: date-time
+                type: string
+              lastRun:
+                description: LastRun tells us the time the last backup job started.
+                format: date-time
+                type: string
+              lastSuccess:
+                description: LastSuccess gives us the time the last successful backup finished.
+                format: date-time
+                type: string
+              output:
+                description: Output reports useful information from the backup_script.
+                type: string
+              pod:
+                description: Pod tells us which pod is running/ran last.
+                type: string
+              repo:
+                description: Repo is where we are currently performing operations.
+                type: string
+              running:
+                description: Running indicates whether a backup is currently being performed.
+                type: boolean
+            required:
+            - cronjob
+            - failed
+            - job
+            - pod
+            - running
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbasebuckets.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.memoryQuota
-    name: memory quota
-    type: string
-  - JSONPath: .spec.replicas
-    name: replicas
-    type: integer
-  - JSONPath: .spec.ioPriority
-    name: io priority
-    type: string
-  - JSONPath: .spec.evictionPolicy
-    name: eviction policy
-    type: string
-  - JSONPath: .spec.conflictResolution
-    name: conflict resolution
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseBucket
@@ -488,114 +564,121 @@ spec:
     plural: couchbasebuckets
     singular: couchbasebucket
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            compressionMode:
-              description: CouchbaseBucketCompressionMode defines the available compression
-                modes for Couchbase and Ephemeral bucket types.
-              enum:
-              - "off"
-              - passive
-              - active
-              type: string
-            conflictResolution:
-              description: CouchbsaeBucketConflictResolution defines the XDCR conflict
-                resolution for a bucket.
-              enum:
-              - seqno
-              - lww
-              type: string
-            enableFlush:
-              type: boolean
-            enableIndexReplica:
-              type: boolean
-            evictionPolicy:
-              description: CouchbaseBucketEvictionPolicy defines the available eviction
-                policies for Couchbase bucket types.
-              enum:
-              - valueOnly
-              - fullEviction
-              type: string
-            ioPriority:
-              description: CouchbaseBucketIOPriority defines the priority of a bucket.
-              enum:
-              - low
-              - high
-              type: string
-            maxTTL:
-              type: string
-            memoryQuota:
-              anyOf:
-              - type: integer
-              - type: string
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            minimumDurability:
-              description: CouchbaseBucketMinimumDurability is the miniumum durability
-                that writes to a bucket should conform to.  Clients can explicitly
-                write with a stricter policy.
-              enum:
-              - none
-              - majority
-              - majorityAndPersistActive
-              - persistToMajority
-              type: string
-            name:
-              maxLength: 100
-              pattern: ^[a-zA-Z0-9-_%\.]+$
-              type: string
-            replicas:
-              maximum: 3
-              minimum: 0
-              type: integer
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.memoryQuota
+      name: memory quota
+      type: string
+    - jsonPath: .spec.replicas
+      name: replicas
+      type: integer
+    - jsonPath: .spec.ioPriority
+      name: io priority
+      type: string
+    - jsonPath: .spec.evictionPolicy
+      name: eviction policy
+      type: string
+    - jsonPath: .spec.conflictResolution
+      name: conflict resolution
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: The CouchbaseBucket resource defines a set of documents in Couchbase server. A Couchbase client connects to and operates on a bucket, which provides independent management of a set documents and a security boundary for role based access control. A CouchbaseBucket provides replication and persistence for documents contained by it.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            default: {}
+            description: CouchbaseBucketSpec is the specification for a Couchbase bucket resource, and allows the bucket to be customized.
+            properties:
+              compressionMode:
+                default: passive
+                description: CompressionMode defines how Couchbase server handles document compression.  When off, documents are stored in memory, and transferred to the client uncompressed. When passive, documents are stored compressed in memory, and transferred to the client compressed when requested.  When active, documents are stored compresses in memory and when transferred to the client.  This field must be "off", "passive" or "active", defaulting to "passive".  Be aware "off" in YAML 1.2 is a boolean, so must be quoted as a string in configuration files.
+                enum:
+                - "off"
+                - passive
+                - active
+                type: string
+              conflictResolution:
+                default: seqno
+                description: ConflictResolution defines how XDCR handles concurrent write conflicts.  Sequence number based resolution selects the document with the highest sequence number as the most recent. Timestamp based resolution selects the document that was written to most recently as the most recent.  This field must be "seqno" (sequence based), or "lww" (timestamp based), defaulting to "seqno".
+                enum:
+                - seqno
+                - lww
+                type: string
+              enableFlush:
+                description: EnableFlush defines whether a client can delete all documents in a bucket. This field defaults to false.
+                type: boolean
+              enableIndexReplica:
+                description: EnableIndexReplica defines whether indexes for this bucket are replicated. This field defaults to false.
+                type: boolean
+              evictionPolicy:
+                default: valueOnly
+                description: EvictionPolicy controls how Couchbase handles memory exhaustion.  Value only eviction flushes documents to disk but maintains document metadata in memory in order to improve query performance.  Full eviction removes all data from memory after the document is flushed to disk.  This field must be "valueOnly" or "fullEviction", defaulting to "valueOnly".
+                enum:
+                - valueOnly
+                - fullEviction
+                type: string
+              ioPriority:
+                default: low
+                description: IOPriority controls how many threads a bucket has, per pod, to process reads and writes. This field must be "low" or "high", defaulting to "low".  Modification of this field will cause a temporary service disruption as threads are restarted.
+                enum:
+                - low
+                - high
+                type: string
+              maxTTL:
+                description: 'MaxTTL defines how long a document is permitted to exist for, without modification, until it is automatically deleted.  This is a default and maximum time-to-live and may be set to a lower value by the client.  If the client specifies a higher value, then it is truncated to the maximum durability.  Documents are removed by Couchbase, after they have expired, when either accessed, the expiry pager is run, or the bucket is compacted.  When set to 0, then documents are not expired by default.  This field must be a duration in the range 0-2147483648s, defaulting to 0.  More info: https://golang.org/pkg/time/#ParseDuration'
+                type: string
+              memoryQuota:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 100Mi
+                description: 'MemoryQuota is a memory limit to the size of a bucket.  When this limit is exceeded, documents will be evicted from memory to disk as defined by the eviction policy.  The memory quota is defined per Couchbase pod running the data service.  This field defaults to, and must be greater than or equal to 100Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                type: string
+                x-kubernetes-int-or-string: true
+              minimumDurability:
+                description: MiniumumDurability defines how durable a document write is by default, and can be made more durable by the client.  This feature enables ACID transactions. When none, Couchbase server will respond when the document is in memory, it will become eventually consistent across the cluster.  When majority, Couchbase server will respond when the document is replicated to at least half of the pods running the data service in the cluster.  When majorityAndPersistActive, Couchbase server will respond when the document is replicated to at least half of the pods running the data service in the cluster and the document has been persisted to disk on the document master pod.  When persistToMajority, Couchbase server will respond when the document is replicated and persisted to disk on at least half of the pods running the data service in the cluster.  This field must be either "none", "majority", "majorityAndPersistActive" or "persistToMajority", defaulting to "none".
+                enum:
+                - none
+                - majority
+                - majorityAndPersistActive
+                - persistToMajority
+                type: string
+              name:
+                description: Name is the name of the bucket within Couchbase server.  By default the Operator will use the `metadata.name` field to define the bucket name.  The `metadata.name` field only supports a subset of the supported character set.  When specified, this field overrides `metadata.name`.  Legal bucket names have a maximum length of 100 characters and may be composed of any character from "a-z", "A-Z", "0-9" and "-_%\.".
+                maxLength: 100
+                pattern: ^[a-zA-Z0-9-_%\.]+$
+                type: string
+              replicas:
+                default: 1
+                description: Replicas defines how many copies of documents Couchbase server maintains.  This directly affects how fault tolerant a Couchbase cluster is.  With a single replica, the cluster can tolerate one data pod going down and still service requests without data loss.  The number of replicas also affect memory use.  With a single replica, the effective memory quota for documents is halved, with two replicas it is one third.  The number of replicas must be between 0 and 3, defaulting to 1.
+                maximum: 3
+                minimum: 0
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbaseclusters.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.currentVersion
-    name: version
-    type: string
-  - JSONPath: .status.size
-    name: size
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Available")].reason
-    name: status
-    type: string
-  - JSONPath: .status.clusterId
-    name: uuid
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseCluster
@@ -605,6545 +688,101 @@ spec:
     - cbc
     singular: couchbasecluster
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            antiAffinity:
-              description: AntiAffinity determines if the couchbase-operator tries
-                to avoid putting the couchbase members in the same cluster onto the
-                same node.
-              type: boolean
-            backup:
-              description: Backup specific settings
-              properties:
-                image:
-                  description: The Backup Image to run on backup pods
-                  type: string
-                imagePullSecrets:
-                  description: ImagePullSecrets allow you to use an image from private
-                    repos and non-dockerhub ones.
-                  items:
-                    description: LocalObjectReference contains enough information
-                      to let you locate the referenced object inside the same namespace.
-                    properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                    type: object
-                  type: array
-                managed:
-                  description: Managed defines whether backups are managed by us or
-                    the clients.
-                  type: boolean
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector defines which nodes to constrain the pods
-                    that run any backup operations to
-                  type: object
-                resources:
-                  description: Resources is the resource requirements for the backup
-                    container. This field cannot be updated once the cluster is created.
-                    Will be populated by defaults if not specified.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                s3Secret:
-                  description: S3Secret contains the region and credentials for operating
-                    backups in S3
-                  type: string
-                selector:
-                  description: Selector allows CouchbaseBackup and CouchbaseBackupRestore
-                    resources to be filtered based on labels.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: The Service Account to run backup (and restore) pods
-                    under. Without this backup pods will not be able to update status
-                  type: string
-                tolerations:
-                  description: Tolerations specifies all backup pod tolerations.
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              type: object
-            buckets:
-              description: Bucket specific settings
-              properties:
-                managed:
-                  description: Managed defines whether buckets are managed by us or
-                    the clients.
-                  type: boolean
-                selector:
-                  description: Selector is a label selector used to list buckets in
-                    the namespace that are managed by the Operator.
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-              type: object
-            cluster:
-              description: Cluster specific settings
-              properties:
-                analyticsServiceMemoryQuota:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: The amount of memory that should be allocated to the
-                    analytics service
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                autoCompaction:
-                  description: Auto-compaction settings
-                  properties:
-                    databaseFragmentationThreshold:
-                      description: DatabaseFragmentationThreshold lists triggers for
-                        when database compaction should start.
-                      properties:
-                        percent:
-                          description: Percent is the percentage of disk fragmentation
-                            (2-100).
-                          maximum: 100
-                          minimum: 2
-                          type: integer
-                        size:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: Size is the size of disk framentation.
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    parallelCompaction:
-                      description: ParallelCompaction controls whether database and
-                        view compactions can happen in parallel.
-                      type: boolean
-                    timeWindow:
-                      description: TimeWindow allows the user to restrict when compaction
-                        can occur.
-                      properties:
-                        abortCompactionOutsideWindow:
-                          description: AbortCompactionOutsideWindow stops compaction
-                            processes when the process moves outside the window.
-                          type: boolean
-                        end:
-                          description: End is a string in the form HH:MM.
-                          pattern: ^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$
-                          type: string
-                        start:
-                          description: Start is a string in the form HH:MM.
-                          pattern: ^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$
-                          type: string
-                      type: object
-                    tombstonePurgeInterval:
-                      description: TombstonePurgeInterval controls how long to wait
-                        before purging tombstones.
-                      type: string
-                    viewFragmentationThreshold:
-                      description: ViewFragmentationThreshold lists triggers for when
-                        view compaction should start.
-                      properties:
-                        percent:
-                          description: Percent is the percentage of disk fragmentation
-                            (2-100).
-                          maximum: 100
-                          minimum: 2
-                          type: integer
-                        size:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: Size is the size of disk framentation.
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                  type: object
-                autoFailoverMaxCount:
-                  description: The number of failover events we can tolerate
-                  format: int64
-                  type: integer
-                autoFailoverOnDataDiskIssues:
-                  description: Whether to auto failover if disk issues are detected
-                  type: boolean
-                autoFailoverOnDataDiskIssuesTimePeriod:
-                  description: How long to wait for transient errors before failing
-                    over a faulty disk
-                  type: string
-                autoFailoverServerGroup:
-                  description: Whether to enable failing over a server group
-                  type: boolean
-                autoFailoverTimeout:
-                  description: Timeout that expires to trigger the auto failover.
-                  type: string
-                clusterName:
-                  description: The name of the cluster
-                  type: string
-                dataServiceMemoryQuota:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: The amount of memory that should be allocated to the
-                    data service
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                eventingServiceMemoryQuota:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: The amount of memory that should be allocated to the
-                    eventing service
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                indexServiceMemoryQuota:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: The amount of memory that should be allocated to the
-                    index service
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                indexStorageSetting:
-                  description: The index storage mode to use for secondary indexing
-                    (DEPRECATED)
-                  enum:
-                  - memory_optimized
-                  - plasma
-                  type: string
-                indexer:
-                  description: Indexer allows the small number of index variables
-                    to be tuned. If specified this attribute overrides `indexStorageSetting`.
-                  properties:
-                    logLevel:
-                      description: LogLevel controls the verbosity of indexer logs.
-                      enum:
-                      - silent
-                      - fatal
-                      - error
-                      - warn
-                      - info
-                      - verbose
-                      - timing
-                      - debug
-                      - trace
-                      type: string
-                    maxRollbackPoints:
-                      description: MaxRollbackPoints controls the number of checkpoints
-                        that can be rolled back to.  The default is 2, with a minimum
-                        of 1.
-                      minimum: 1
-                      type: integer
-                    memorySnapshotInterval:
-                      description: MemorySnapshotInterval controls when memory indexes
-                        should be snapshotted. This defaults to 200ms, and must be
-                        greater than or eqaul to 1ms.
-                      type: string
-                    stableSnapshotInterval:
-                      description: StableSnapshotInterval controls when disk indexes
-                        should be snapshotted. This defaults to 5s, and must be greater
-                        than or equal to 1ms.
-                      type: string
-                    storageMode:
-                      description: StorageMode controls the underlying storage engine
-                        for indexes.  Once set it can only be modified if there are
-                        no nodes in the cluster running the index service.
-                      enum:
-                      - memory_optimized
-                      - plasma
-                      type: string
-                    threads:
-                      description: Threads controls the number of processor threads
-                        to use for indexing. A value of 0 means 1 per CPU (default).  This
-                        attribute must be greater than or equal to 0.
-                      minimum: 0
-                      type: integer
-                  type: object
-                searchServiceMemoryQuota:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: The amount of memory that should be allocated to the
-                    search service
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-              type: object
-            enablePreviewScaling:
-              description: EnablePreviewScaling enables autoscaling for stateful services
-                and buckets
-              type: boolean
-            hibernate:
-              description: Hibernate is whether to hibernate the cluster.
-              type: boolean
-            hibernationStrategy:
-              description: HibernationStrategy is how aggressive the are when hibernating.
-              enum:
-              - Immediate
-              type: string
-            image:
-              description: BaseImage is the base couchbase image name that will be
-                used to launch couchbase clusters. This is useful for private registries,
-                etc.
-              pattern: ^(.*?(:\d+)?/)?.*?/.*?(:.*?\d+\.\d+\.\d+.*|@sha256:[0-9a-f]{64})$
-              type: string
-            logging:
-              description: Logging groups together logging related options.
-              properties:
-                logRetentionCount:
-                  description: LogRetentionCount gives the number of persistent log
-                    PVCs to keep.
-                  minimum: 0
-                  type: integer
-                logRetentionTime:
-                  description: LogRetentionTime gives the time to keep persistent
-                    log PVCs alive for.
-                  pattern: ^\d+(ns|us|ms|s|m|h)$
-                  type: string
-              type: object
-            monitoring:
-              description: Prometheus Monitoring settings.
-              properties:
-                prometheus:
-                  properties:
-                    authorizationSecret:
-                      description: AuthorizationSecret is the name of a Kubernetes
-                        secret that contains a bearer token to authorize GET requests
-                        to the metrics endpoint
-                      type: string
-                    enabled:
-                      description: Enabled is a boolean that enables/disables the
-                        metrics sidecar container.
-                      type: boolean
-                    image:
-                      description: Image is the metrics image to be used to collect
-                        metrics.
-                      pattern: ^[\w_\.\-/]+:([\w\d]+-)?\d+\.\d+.\d+(-[\w\d]+)?$
-                      type: string
-                    resources:
-                      description: Resources is the resource requirements for the
-                        metrics container. This field cannot be updated once the cluster
-                        is created. Will be populated by defaults if not specified.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                  type: object
-              type: object
-            networking:
-              description: Networking groups together related networking options.
-              properties:
-                adminConsoleServiceTemplate:
-                  description: AdminConsoleServiceTemplate provides user access to
-                    every possible field so they can control anything they want.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    spec:
-                      description: ServiceSpec describes the attributes that a user
-                        creates on a service.
-                      properties:
-                        clusterIP:
-                          description: 'clusterIP is the IP address of the service
-                            and is usually assigned randomly by the master. If an
-                            address is specified manually and is not in use by others,
-                            it will be allocated to the service; otherwise, creation
-                            of the service will fail. This field can not be changed
-                            through updates. Valid values are "None", empty string
-                            (""), or a valid IP address. "None" can be specified for
-                            headless services when proxying is not required. Only
-                            applies to types ClusterIP, NodePort, and LoadBalancer.
-                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        externalIPs:
-                          description: externalIPs is a list of IP addresses for which
-                            nodes in the cluster will also accept traffic for this
-                            service.  These IPs are not managed by Kubernetes.  The
-                            user is responsible for ensuring that traffic arrives
-                            at a node with this IP.  A common example is external
-                            load-balancers that are not part of the Kubernetes system.
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          description: externalName is the external reference that
-                            kubedns or equivalent will return as a CNAME record for
-                            this service. No proxying will be involved. Must be a
-                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                            and requires Type to be ExternalName.
-                          type: string
-                        externalTrafficPolicy:
-                          description: externalTrafficPolicy denotes if this Service
-                            desires to route external traffic to node-local or cluster-wide
-                            endpoints. "Local" preserves the client source IP and
-                            avoids a second hop for LoadBalancer and Nodeport type
-                            services, but risks potentially imbalanced traffic spreading.
-                            "Cluster" obscures the client source IP and may cause
-                            a second hop to another node, but should have good overall
-                            load-spreading.
-                          type: string
-                        healthCheckNodePort:
-                          description: healthCheckNodePort specifies the healthcheck
-                            nodePort for the service. If not specified, HealthCheckNodePort
-                            is created by the service api backend with the allocated
-                            nodePort. Will use user-specified nodePort value if specified
-                            by the client. Only effects when Type is set to LoadBalancer
-                            and ExternalTrafficPolicy is set to Local.
-                          format: int32
-                          type: integer
-                        ipFamily:
-                          description: ipFamily specifies whether this Service has
-                            a preference for a particular IP family (e.g. IPv4 vs.
-                            IPv6).  If a specific IP family is requested, the clusterIP
-                            field will be allocated from that family, if it is available
-                            in the cluster.  If no IP family is requested, the cluster's
-                            primary IP family will be used. Other IP fields (loadBalancerIP,
-                            loadBalancerSourceRanges, externalIPs) and controllers
-                            which allocate external load-balancers should use the
-                            same IP family.  Endpoints for this Service will be of
-                            this family.  This field is immutable after creation.
-                            Assigning a ServiceIPFamily not available in the cluster
-                            (e.g. IPv6 in IPv4 only cluster) is an error condition
-                            and will fail during clusterIP assignment.
-                          type: string
-                        loadBalancerIP:
-                          description: 'Only applies to Service Type: LoadBalancer
-                            LoadBalancer will get created with the IP specified in
-                            this field. This feature depends on whether the underlying
-                            cloud-provider supports specifying the loadBalancerIP
-                            when a load balancer is created. This field will be ignored
-                            if the cloud-provider does not support the feature.'
-                          type: string
-                        loadBalancerSourceRanges:
-                          description: 'If specified and supported by the platform,
-                            this will restrict traffic through the cloud-provider
-                            load-balancer will be restricted to the specified client
-                            IPs. This field will be ignored if the cloud-provider
-                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                          items:
-                            type: string
-                          type: array
-                        ports:
-                          description: 'The list of ports that are exposed by this
-                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          items:
-                            description: ServicePort contains information on service's
-                              port.
-                            properties:
-                              name:
-                                description: The name of this port within the service.
-                                  This must be a DNS_LABEL. All ports within a ServiceSpec
-                                  must have unique names. When considering the endpoints
-                                  for a Service, this must match the 'name' field
-                                  in the EndpointPort. Optional if only one ServicePort
-                                  is defined on this service.
-                                type: string
-                              nodePort:
-                                description: 'The port on each node on which this
-                                  service is exposed when type=NodePort or LoadBalancer.
-                                  Usually assigned by the system. If specified, it
-                                  will be allocated to the service if unused or else
-                                  creation of the service will fail. Default is to
-                                  auto-allocate a port if the ServiceType of this
-                                  Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                                format: int32
-                                type: integer
-                              port:
-                                description: The port that will be exposed by this
-                                  service.
-                                format: int32
-                                type: integer
-                              protocol:
-                                description: The IP protocol for this port. Supports
-                                  "TCP", "UDP", and "SCTP". Default is TCP.
-                                type: string
-                              targetPort:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: 'Number or name of the port to access
-                                  on the pods targeted by the service. Number must
-                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                  If this is a string, it will be looked up as a named
-                                  port in the target Pod''s container ports. If this
-                                  is not specified, the value of the ''port'' field
-                                  is used (an identity map). This field is ignored
-                                  for services with clusterIP=None, and should be
-                                  omitted or set equal to the ''port'' field. More
-                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          type: array
-                        publishNotReadyAddresses:
-                          description: publishNotReadyAddresses, when set to true,
-                            indicates that DNS implementations must publish the notReadyAddresses
-                            of subsets for the Endpoints associated with the Service.
-                            The default value is false. The primary use case for setting
-                            this field is to use a StatefulSet's Headless Service
-                            to propagate SRV records for its Pods without respect
-                            to their readiness for purpose of peer discovery.
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          description: 'Route service traffic to pods with label keys
-                            and values matching this selector. If empty or not present,
-                            the service is assumed to have an external process managing
-                            its endpoints, which Kubernetes will not modify. Only
-                            applies to types ClusterIP, NodePort, and LoadBalancer.
-                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                          type: object
-                        sessionAffinity:
-                          description: 'Supports "ClientIP" and "None". Used to maintain
-                            session affinity. Enable client IP based session affinity.
-                            Must be ClientIP or None. Defaults to None. More info:
-                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        sessionAffinityConfig:
-                          description: sessionAffinityConfig contains the configurations
-                            of session affinity.
-                          properties:
-                            clientIP:
-                              description: clientIP contains the configurations of
-                                Client IP based session affinity.
-                              properties:
-                                timeoutSeconds:
-                                  description: timeoutSeconds specifies the seconds
-                                    of ClientIP type session sticky time. The value
-                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                    == "ClientIP". Default value is 10800(for 3 hours).
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        topologyKeys:
-                          description: topologyKeys is a preference-order list of
-                            topology keys which implementations of services should
-                            use to preferentially sort endpoints when accessing this
-                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
-                            Topology keys must be valid label keys and at most 16
-                            keys may be specified. Endpoints are chosen based on the
-                            first topology key with available backends. If this field
-                            is specified and all entries have no backends that match
-                            the topology of the client, the service has no backends
-                            for that client and connections should fail. The special
-                            value "*" may be used to mean "any topology". This catch-all
-                            value, if used, only makes sense as the last value in
-                            the list. If this is not specified or empty, no topology
-                            constraints will be applied.
-                          items:
-                            type: string
-                          type: array
-                        type:
-                          description: 'type determines how the Service is exposed.
-                            Defaults to ClusterIP. Valid options are ExternalName,
-                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
-                            maps to the specified externalName. "ClusterIP" allocates
-                            a cluster-internal IP address for load-balancing to endpoints.
-                            Endpoints are determined by the selector or if that is
-                            not specified, by manual construction of an Endpoints
-                            object. If clusterIP is "None", no virtual IP is allocated
-                            and the endpoints are published as a set of endpoints
-                            rather than a stable IP. "NodePort" builds on ClusterIP
-                            and allocates a port on every node which routes to the
-                            clusterIP. "LoadBalancer" builds on NodePort and creates
-                            an external load-balancer (if supported in the current
-                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                          type: string
-                      type: object
-                  type: object
-                adminConsoleServiceType:
-                  description: DEPRECATED this will be removed in a later release.
-                    AdminConsoleServiceType defines whether to create a NodePort or
-                    LoadBalancer service.
-                  enum:
-                  - NodePort
-                  - LoadBalancer
-                  type: string
-                adminConsoleServices:
-                  description: DEPRECATED from Couchbase Server 6.5.0 onwards. AdminConsoleServices
-                    is a selector to choose specific services to expose via the admin
-                    console.
-                  items:
-                    description: Supported services
-                    enum:
-                    - admin
-                    - data
-                    - index
-                    - query
-                    - search
-                    - eventing
-                    - analytics
-                    type: string
-                  type: array
-                dns:
-                  description: DNS points to information for Dynamic DNS support.
-                  properties:
-                    domain:
-                      description: Domain is the domain to create pods in.
-                      type: string
-                  type: object
-                exposeAdminConsole:
-                  description: ExposeAdminConsole creates a service referencing the
-                    admin console.
-                  type: boolean
-                exposedFeatureServiceTemplate:
-                  description: ExposedFeatureServiceTemplate provides user access
-                    to every possible field so they can control anything they want.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    spec:
-                      description: ServiceSpec describes the attributes that a user
-                        creates on a service.
-                      properties:
-                        clusterIP:
-                          description: 'clusterIP is the IP address of the service
-                            and is usually assigned randomly by the master. If an
-                            address is specified manually and is not in use by others,
-                            it will be allocated to the service; otherwise, creation
-                            of the service will fail. This field can not be changed
-                            through updates. Valid values are "None", empty string
-                            (""), or a valid IP address. "None" can be specified for
-                            headless services when proxying is not required. Only
-                            applies to types ClusterIP, NodePort, and LoadBalancer.
-                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        externalIPs:
-                          description: externalIPs is a list of IP addresses for which
-                            nodes in the cluster will also accept traffic for this
-                            service.  These IPs are not managed by Kubernetes.  The
-                            user is responsible for ensuring that traffic arrives
-                            at a node with this IP.  A common example is external
-                            load-balancers that are not part of the Kubernetes system.
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          description: externalName is the external reference that
-                            kubedns or equivalent will return as a CNAME record for
-                            this service. No proxying will be involved. Must be a
-                            valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                            and requires Type to be ExternalName.
-                          type: string
-                        externalTrafficPolicy:
-                          description: externalTrafficPolicy denotes if this Service
-                            desires to route external traffic to node-local or cluster-wide
-                            endpoints. "Local" preserves the client source IP and
-                            avoids a second hop for LoadBalancer and Nodeport type
-                            services, but risks potentially imbalanced traffic spreading.
-                            "Cluster" obscures the client source IP and may cause
-                            a second hop to another node, but should have good overall
-                            load-spreading.
-                          type: string
-                        healthCheckNodePort:
-                          description: healthCheckNodePort specifies the healthcheck
-                            nodePort for the service. If not specified, HealthCheckNodePort
-                            is created by the service api backend with the allocated
-                            nodePort. Will use user-specified nodePort value if specified
-                            by the client. Only effects when Type is set to LoadBalancer
-                            and ExternalTrafficPolicy is set to Local.
-                          format: int32
-                          type: integer
-                        ipFamily:
-                          description: ipFamily specifies whether this Service has
-                            a preference for a particular IP family (e.g. IPv4 vs.
-                            IPv6).  If a specific IP family is requested, the clusterIP
-                            field will be allocated from that family, if it is available
-                            in the cluster.  If no IP family is requested, the cluster's
-                            primary IP family will be used. Other IP fields (loadBalancerIP,
-                            loadBalancerSourceRanges, externalIPs) and controllers
-                            which allocate external load-balancers should use the
-                            same IP family.  Endpoints for this Service will be of
-                            this family.  This field is immutable after creation.
-                            Assigning a ServiceIPFamily not available in the cluster
-                            (e.g. IPv6 in IPv4 only cluster) is an error condition
-                            and will fail during clusterIP assignment.
-                          type: string
-                        loadBalancerIP:
-                          description: 'Only applies to Service Type: LoadBalancer
-                            LoadBalancer will get created with the IP specified in
-                            this field. This feature depends on whether the underlying
-                            cloud-provider supports specifying the loadBalancerIP
-                            when a load balancer is created. This field will be ignored
-                            if the cloud-provider does not support the feature.'
-                          type: string
-                        loadBalancerSourceRanges:
-                          description: 'If specified and supported by the platform,
-                            this will restrict traffic through the cloud-provider
-                            load-balancer will be restricted to the specified client
-                            IPs. This field will be ignored if the cloud-provider
-                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
-                          items:
-                            type: string
-                          type: array
-                        ports:
-                          description: 'The list of ports that are exposed by this
-                            service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          items:
-                            description: ServicePort contains information on service's
-                              port.
-                            properties:
-                              name:
-                                description: The name of this port within the service.
-                                  This must be a DNS_LABEL. All ports within a ServiceSpec
-                                  must have unique names. When considering the endpoints
-                                  for a Service, this must match the 'name' field
-                                  in the EndpointPort. Optional if only one ServicePort
-                                  is defined on this service.
-                                type: string
-                              nodePort:
-                                description: 'The port on each node on which this
-                                  service is exposed when type=NodePort or LoadBalancer.
-                                  Usually assigned by the system. If specified, it
-                                  will be allocated to the service if unused or else
-                                  creation of the service will fail. Default is to
-                                  auto-allocate a port if the ServiceType of this
-                                  Service requires one. More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                                format: int32
-                                type: integer
-                              port:
-                                description: The port that will be exposed by this
-                                  service.
-                                format: int32
-                                type: integer
-                              protocol:
-                                description: The IP protocol for this port. Supports
-                                  "TCP", "UDP", and "SCTP". Default is TCP.
-                                type: string
-                              targetPort:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                description: 'Number or name of the port to access
-                                  on the pods targeted by the service. Number must
-                                  be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
-                                  If this is a string, it will be looked up as a named
-                                  port in the target Pod''s container ports. If this
-                                  is not specified, the value of the ''port'' field
-                                  is used (an identity map). This field is ignored
-                                  for services with clusterIP=None, and should be
-                                  omitted or set equal to the ''port'' field. More
-                                  info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          type: array
-                        publishNotReadyAddresses:
-                          description: publishNotReadyAddresses, when set to true,
-                            indicates that DNS implementations must publish the notReadyAddresses
-                            of subsets for the Endpoints associated with the Service.
-                            The default value is false. The primary use case for setting
-                            this field is to use a StatefulSet's Headless Service
-                            to propagate SRV records for its Pods without respect
-                            to their readiness for purpose of peer discovery.
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          description: 'Route service traffic to pods with label keys
-                            and values matching this selector. If empty or not present,
-                            the service is assumed to have an external process managing
-                            its endpoints, which Kubernetes will not modify. Only
-                            applies to types ClusterIP, NodePort, and LoadBalancer.
-                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                          type: object
-                        sessionAffinity:
-                          description: 'Supports "ClientIP" and "None". Used to maintain
-                            session affinity. Enable client IP based session affinity.
-                            Must be ClientIP or None. Defaults to None. More info:
-                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        sessionAffinityConfig:
-                          description: sessionAffinityConfig contains the configurations
-                            of session affinity.
-                          properties:
-                            clientIP:
-                              description: clientIP contains the configurations of
-                                Client IP based session affinity.
-                              properties:
-                                timeoutSeconds:
-                                  description: timeoutSeconds specifies the seconds
-                                    of ClientIP type session sticky time. The value
-                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                    == "ClientIP". Default value is 10800(for 3 hours).
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        topologyKeys:
-                          description: topologyKeys is a preference-order list of
-                            topology keys which implementations of services should
-                            use to preferentially sort endpoints when accessing this
-                            Service, it can not be used at the same time as externalTrafficPolicy=Local.
-                            Topology keys must be valid label keys and at most 16
-                            keys may be specified. Endpoints are chosen based on the
-                            first topology key with available backends. If this field
-                            is specified and all entries have no backends that match
-                            the topology of the client, the service has no backends
-                            for that client and connections should fail. The special
-                            value "*" may be used to mean "any topology". This catch-all
-                            value, if used, only makes sense as the last value in
-                            the list. If this is not specified or empty, no topology
-                            constraints will be applied.
-                          items:
-                            type: string
-                          type: array
-                        type:
-                          description: 'type determines how the Service is exposed.
-                            Defaults to ClusterIP. Valid options are ExternalName,
-                            ClusterIP, NodePort, and LoadBalancer. "ExternalName"
-                            maps to the specified externalName. "ClusterIP" allocates
-                            a cluster-internal IP address for load-balancing to endpoints.
-                            Endpoints are determined by the selector or if that is
-                            not specified, by manual construction of an Endpoints
-                            object. If clusterIP is "None", no virtual IP is allocated
-                            and the endpoints are published as a set of endpoints
-                            rather than a stable IP. "NodePort" builds on ClusterIP
-                            and allocates a port on every node which routes to the
-                            clusterIP. "LoadBalancer" builds on NodePort and creates
-                            an external load-balancer (if supported in the current
-                            cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                          type: string
-                      type: object
-                  type: object
-                exposedFeatureServiceType:
-                  description: DEPRECATED this will be removed in a later release.
-                    ExposedFeatureServiceType defines whether to create a NodePort
-                    or LoadBalancer service.
-                  enum:
-                  - NodePort
-                  - LoadBalancer
-                  type: string
-                exposedFeatureTrafficPolicy:
-                  description: DEPRECATED this will be removed in a later release.
-                    ExposedFeatureTrafficPolicy defines how packets should be routed.
-                  enum:
-                  - Cluster
-                  - Local
-                  type: string
-                exposedFeatures:
-                  description: ExposedFeatures is a list of features to expose on
-                    the K8S node network.  They represent a subset of ports e.g. admin=8091,
-                    xdcr=8091,8092,11210, and thus may overlap.
-                  items:
-                    enum:
-                    - admin
-                    - xdcr
-                    - client
-                    type: string
-                  type: array
-                loadBalancerSourceRanges:
-                  description: DEPRECATED this will be removed in a later release.
-                    LoadBalancerSourceRanges applies only when an exposed service
-                    is of type LoadBalancer and limits the source IP ranges that are
-                    allowed to use the service.
-                  items:
-                    pattern: ^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$
-                    type: string
-                  type: array
-                networkPlatform:
-                  description: NetworkPlatform is used to enable support for vairous
-                    netwokring technologoes.
-                  enum:
-                  - Istio
-                  type: string
-                serviceAnnotations:
-                  additionalProperties:
-                    type: string
-                  description: DEPRECATED this will be removed in a later release.
-                    ServiceAnnotations allows services to be annotated with custom
-                    labels. Operator annotations are merged on top of these so have
-                    precedence as they are required for correct operation.
-                  type: object
-                tls:
-                  description: TLS contains the TLS configuration for the cluster.
-                  properties:
-                    clientCertificatePaths:
-                      description: ClientCertificatePaths optionally defines where
-                        to look in client certificates to extract the user name.
-                      items:
-                        description: ClientCertificatePath defines how to extract
-                          a username from a client ceritficate.
-                        properties:
-                          delimiter:
-                            description: Delimiter if specified allows a suffix to
-                              be stripped from the username.
-                            type: string
-                          path:
-                            description: Path defines where in the X.509 specification
-                              to extract the username from. Valid values are subject.cn,
-                              san.uri, san.dnsname, san.email.
-                            pattern: ^subject\.cn|san\.uri|san\.dnsname|san\.email$
-                            type: string
-                          prefix:
-                            description: Prefix if specified allows a prefix to be
-                              stripped from the username.
-                            type: string
-                        required:
-                        - path
-                        type: object
-                      type: array
-                    clientCertificatePolicy:
-                      description: ClientCertificatePolicy optionally defines the
-                        policy to use. If set then the OperatorSecret must contain
-                        a valid certificate/key pair for the Administrator account.
-                      enum:
-                      - enable
-                      - mandatory
-                      type: string
-                    nodeToNodeEncryption:
-                      description: NodeToNodeEncryption specifies whether to encrypt
-                        data between Couchbase nodes within the same cluster.  This
-                        may come at the expense of performance.
-                      enum:
-                      - ControlPlaneOnly
-                      - All
-                      type: string
-                    static:
-                      description: StaticTLS enables user to generate static x509
-                        certificates and keys, put them into Kubernetes secrets, and
-                        specify them into here.
-                      properties:
-                        operatorSecret:
-                          description: OperatorSecret is the secret containing TLS
-                            certs used by operator to talk securely to this cluster.
-                          type: string
-                        serverSecret:
-                          description: ServerSecret is the secret containing TLS certs
-                            used by each couchbase member pod for the communication
-                            between couchbase server and its clients.
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            paused:
-              description: Paused is to pause the control of the operator for the
-                couchbase cluster.
-              type: boolean
-            platform:
-              description: Platform gives a hint as to what platform we are running
-                on and how to configure services etc.
-              enum:
-              - aws
-              - gce
-              - azure
-              type: string
-            recoveryPolicy:
-              description: This controls how aggressive we are when recovering cluster
-                topology.
-              enum:
-              - PrioritizeDataIntegrity
-              - PrioritizeUptime
-              type: string
-            security:
-              description: Security groups together related security options.
-              properties:
-                adminSecret:
-                  description: AdminSecret is the name of a kubernetes secret to use
-                    for administrator authentication.
-                  type: string
-                ldap:
-                  description: LDAP Settings
-                  properties:
-                    authenticationEnabled:
-                      description: Enables using LDAP to authenticate users.
-                      type: boolean
-                    authorizationEnabled:
-                      description: Enables use of LDAP groups for authorization.
-                      type: boolean
-                    bindDN:
-                      description: DN to use for searching users and groups synchronization.
-                      type: string
-                    bindSecret:
-                      description: BindSecret is the name of a kubernetes secret to
-                        use containing password for LDAP user binding
-                      type: string
-                    cacert:
-                      description: Certificate in PEM format to be used in LDAP server
-                        certificate validation
-                      type: string
-                    cacheValueLifetime:
-                      description: Lifetime of values in cache in milliseconds. Default
-                        300000 ms.
-                      format: int64
-                      type: integer
-                    encryption:
-                      description: Encryption method to communicate with LDAP servers.
-                        Can be StartTLSExtension, TLS, or false.
-                      enum:
-                      - None
-                      - StartTLSExtension
-                      - TLS
-                      type: string
-                    groupsQuery:
-                      description: LDAP query, to get the users' groups by username
-                        in RFC4516 format.
-                      type: string
-                    hosts:
-                      description: List of LDAP hosts.
-                      items:
-                        type: string
-                      type: array
-                    nestedGroupsEnabled:
-                      description: If enabled Couchbase server will try to recursively
-                        search for groups for every discovered ldap group. groups_query
-                        will be user for the search.
-                      type: boolean
-                    nestedGroupsMaxDepth:
-                      description: 'Maximum number of recursive groups requests the
-                        server is allowed to perform. Requires NestedGroupsEnabled.  Values
-                        between 1 and 100: the default is 10.'
-                      format: int64
-                      type: integer
-                    port:
-                      description: LDAP port
-                      type: integer
-                    serverCertValidation:
-                      description: Whether server certificate validation be enabled
-                      type: boolean
-                    tlsSecret:
-                      description: TLSSecret is the name of a kubernetes secret to
-                        use for LDAP ca cert.
-                      type: string
-                    userDNMapping:
-                      description: User to distinguished name (DN) mapping. If none
-                        is specified, the username is used as the user’s distinguished
-                        name.
-                      properties:
-                        query:
-                          type: string
-                        template:
-                          type: string
-                      type: object
-                  required:
-                  - bindSecret
-                  - hosts
-                  - port
-                  type: object
-                rbac:
-                  description: Couchbase RBAC Users
-                  properties:
-                    managed:
-                      description: Managed defines whether RBAC is managed by us or
-                        the clients.
-                      type: boolean
-                    selector:
-                      description: Selector is a label selector used to list RBAC
-                        resources in the namespace that are managed by the Operator.
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                            - key
-                            - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                  type: object
-              required:
-              - adminSecret
-              type: object
-            securityContext:
-              description: Security Context for all pods
-              properties:
-                fsGroup:
-                  description: "A special supplemental group that applies to all containers
-                    in a pod. Some volume types allow the Kubelet to change the ownership
-                    of that volume to be owned by the pod: \n 1. The owning GID will
-                    be the FSGroup 2. The setgid bit is set (new files created in
-                    the volume will be owned by FSGroup) 3. The permission bits are
-                    OR'd with rw-rw---- \n If unset, the Kubelet will not modify the
-                    ownership and permissions of any volume."
-                  format: int64
-                  type: integer
-                runAsGroup:
-                  description: The GID to run the entrypoint of the container process.
-                    Uses runtime default if unset. May also be set in SecurityContext.  If
-                    set in both SecurityContext and PodSecurityContext, the value
-                    specified in SecurityContext takes precedence for that container.
-                  format: int64
-                  type: integer
-                runAsNonRoot:
-                  description: Indicates that the container must run as a non-root
-                    user. If true, the Kubelet will validate the image at runtime
-                    to ensure that it does not run as UID 0 (root) and fail to start
-                    the container if it does. If unset or false, no such validation
-                    will be performed. May also be set in SecurityContext.  If set
-                    in both SecurityContext and PodSecurityContext, the value specified
-                    in SecurityContext takes precedence.
-                  type: boolean
-                runAsUser:
-                  description: The UID to run the entrypoint of the container process.
-                    Defaults to user specified in image metadata if unspecified. May
-                    also be set in SecurityContext.  If set in both SecurityContext
-                    and PodSecurityContext, the value specified in SecurityContext
-                    takes precedence for that container.
-                  format: int64
-                  type: integer
-                seLinuxOptions:
-                  description: The SELinux context to be applied to all containers.
-                    If unspecified, the container runtime will allocate a random SELinux
-                    context for each container.  May also be set in SecurityContext.  If
-                    set in both SecurityContext and PodSecurityContext, the value
-                    specified in SecurityContext takes precedence for that container.
-                  properties:
-                    level:
-                      description: Level is SELinux level label that applies to the
-                        container.
-                      type: string
-                    role:
-                      description: Role is a SELinux role label that applies to the
-                        container.
-                      type: string
-                    type:
-                      description: Type is a SELinux type label that applies to the
-                        container.
-                      type: string
-                    user:
-                      description: User is a SELinux user label that applies to the
-                        container.
-                      type: string
-                  type: object
-                supplementalGroups:
-                  description: A list of groups applied to the first process run in
-                    each container, in addition to the container's primary GID.  If
-                    unspecified, no groups will be added to any container.
-                  items:
-                    format: int64
-                    type: integer
-                  type: array
-                sysctls:
-                  description: Sysctls hold a list of namespaced sysctls used for
-                    the pod. Pods with unsupported sysctls (by the container runtime)
-                    might fail to launch.
-                  items:
-                    description: Sysctl defines a kernel parameter to be set
-                    properties:
-                      name:
-                        description: Name of a property to set
-                        type: string
-                      value:
-                        description: Value of a property to set
-                        type: string
-                    required:
-                    - name
-                    - value
-                    type: object
-                  type: array
-                windowsOptions:
-                  description: The Windows specific settings applied to all containers.
-                    If unspecified, the options within a container's SecurityContext
-                    will be used. If set in both SecurityContext and PodSecurityContext,
-                    the value specified in SecurityContext takes precedence.
-                  properties:
-                    gmsaCredentialSpec:
-                      description: GMSACredentialSpec is where the GMSA admission
-                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                        inlines the contents of the GMSA credential spec named by
-                        the GMSACredentialSpecName field. This field is alpha-level
-                        and is only honored by servers that enable the WindowsGMSA
-                        feature flag.
-                      type: string
-                    gmsaCredentialSpecName:
-                      description: GMSACredentialSpecName is the name of the GMSA
-                        credential spec to use. This field is alpha-level and is only
-                        honored by servers that enable the WindowsGMSA feature flag.
-                      type: string
-                    runAsUserName:
-                      description: The UserName in Windows to run the entrypoint of
-                        the container process. Defaults to the user specified in image
-                        metadata if unspecified. May also be set in PodSecurityContext.
-                        If set in both SecurityContext and PodSecurityContext, the
-                        value specified in SecurityContext takes precedence. This
-                        field is beta-level and may be disabled with the WindowsRunAsUserName
-                        feature flag.
-                      type: string
-                  type: object
-              type: object
-            serverGroups:
-              description: ServerGroups define the set of availability zones we want
-                to distribute pods over.  This allows the Kubernetes cluster administrator
-                to label all nodes, but use a specific subset for a particular Couchbase
-                cluster.
-              items:
-                type: string
-              type: array
-            servers:
-              description: Servers specifies
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.currentVersion
+      name: version
+      type: string
+    - jsonPath: .status.size
+      name: size
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
+      name: status
+      type: string
+    - jsonPath: .status.clusterId
+      name: uuid
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: The CouchbaseCluster resource represents a Couchbase cluster.  It allows configuration of cluster topology, networking, storage and security options.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec is the specification for a CouchbaseCluster resources, and allows the cluster to be customized.
+            properties:
+              antiAffinity:
+                description: AntiAffinity forces the Operator to schedule different Couchbase server pods on different Kubernetes nodes.  Anti-affinity reduces the likelihood of unrecoverable failure in the event of a node issue.  Use of anti-affinity is highly recommended for production clusters.
+                type: boolean
+              autoResourceAllocation:
+                description: AutoResourceAllocation populates pod resource requests based on the services running on that pod.  When enabled, this feature will calculate the memory request as the total of service allocations defined in `spec.cluster`, plus an overhead defined by `spec.autoResourceAllocation.overheadPercent`.Changing individual allocations for a service will cause a cluster upgrade as allocations are modified in the underlying pods.  This field also allows default pod CPU requests and limits to be applied. All resource allocations can be overridden by explcitly configuring them in the `spec.servers.resources` field.
                 properties:
-                  autoscaleEnabled:
-                    description: Enabled defines whether Autoscale feature is enabled
-                      for this config
+                  cpuLimits:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: "4"
+                    description: 'CPULimits automatically populates the CPU limits across all Couchbase server pods.  This field defaults to "4" CPUs.  Explicitly specifying the CPU limit for a particular server class will override this value.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  cpuRequests:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: "2"
+                    description: 'CPURequests automatically populates the CPU requests across all Couchbase server pods.  The default vaule of "2", is the minimum recommended number of CPUs required to run Couchbase Server.  Explicitly specifying the CPU request for a particular server class will override this value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  enabled:
+                    description: Enabled defines whether auto-resource allocation is enabled.
                     type: boolean
-                  env:
-                    description: List of environment variables to set in the couchbase
-                      container. This is used to configure couchbase process. couchbase
-                      cluster cannot be created, when bad environement variables are
-                      provided. Do not overwrite any flags used to bootstrap the cluster
-                      (for example `--initial-cluster` flag). This field cannot be
-                      updated.
+                  overheadPercent:
+                    default: 25
+                    description: OverheadPercent defines the amount of memory above that required for individual services on a pod.  For Couchbase Server this should be approximately 25%.
+                    minimum: 0
+                    type: integer
+                type: object
+              autoscaleStabilizationPeriod:
+                description: "AutoscaleStabilizationPeriod defines how long after a rebalance the corresponding HorizontalPodAutoscaler should remain in maintenance mode. During maintenance mode all autoscaling is disabled since every HorizontalPodAutoscaler associated with the cluster becomes inactive. Since certain metrics can be unpredictable when Couchbase is rebalancing or upgrading, setting a stabilization period helps to prevent scaling recommendations from the HorizontalPodAutoscaler for a provided period of time. \n Values must be a valid Kubernetes duration of 0s or higher: https://golang.org/pkg/time/#ParseDuration A value of 0, puts the cluster in maintenance mode during rebalance but immediately exits this mode once the rebalance has completed. When undefined, the HPA is never put into maintenance mode during rebalance."
+                type: string
+              backup:
+                description: Backup defines whether the Operator should manage automated backups, and how to lookup backup resources.
+                properties:
+                  image:
+                    description: The Backup Image to run on backup pods
+                    type: string
+                  imagePullSecrets:
+                    description: ImagePullSecrets allow you to use an image from private repositories and non-dockerhub ones.
                     items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
+                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                       properties:
                         name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                        value:
-                          description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                          type: string
-                        valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
-                          properties:
-                            configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                            fieldRef:
-                              description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, metadata.labels, metadata.annotations,
-                                spec.nodeName, spec.serviceAccountName, status.hostIP,
-                                status.podIP, status.podIPs.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                            secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                          type: object
-                      required:
-                      - name
                       type: object
                     type: array
-                  envFrom:
-                    description: EnvFrom allows the setting of environment variables
-                      from things like Secrets and ConfigMaps.
-                    items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps
-                      properties:
-                        configMapRef:
-                          description: The ConfigMap to select from
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap must be defined
-                              type: boolean
-                          type: object
-                        prefix:
-                          description: An optional identifier to prepend to each key
-                            in the ConfigMap. Must be a C_IDENTIFIER.
-                          type: string
-                        secretRef:
-                          description: The Secret to select from
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret must be defined
-                              type: boolean
-                          type: object
-                      type: object
-                    type: array
-                  name:
-                    description: A name for the server configuration. It must be unique.
-                    type: string
-                  pod:
-                    description: "Pod defines the policy to create pod for the couchbase
-                      pod. \n Updating Pod does not take effect on any existing couchbase
-                      pods."
-                    properties:
-                      metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        type: object
-                      spec:
-                        description: 'Specification of the desired behavior of the
-                          pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                        properties:
-                          activeDeadlineSeconds:
-                            description: Optional duration in seconds the pod may
-                              be active on the node relative to StartTime before the
-                              system will actively try to mark it failed and kill
-                              associated containers. Value must be a positive integer.
-                            format: int64
-                            type: integer
-                          affinity:
-                            description: If specified, the pod's scheduling constraints
-                            properties:
-                              nodeAffinity:
-                                description: Describes node affinity scheduling rules
-                                  for the pod.
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
-                                      pods to nodes that satisfy the affinity expressions
-                                      specified by this field, but it may choose a
-                                      node that violates one or more of the expressions.
-                                      The node that is most preferred is the one with
-                                      the greatest sum of weights, i.e. for each node
-                                      that meets all of the scheduling requirements
-                                      (resource request, requiredDuringScheduling
-                                      affinity expressions, etc.), compute a sum by
-                                      iterating through the elements of this field
-                                      and adding "weight" to the sum if the node matches
-                                      the corresponding matchExpressions; the node(s)
-                                      with the highest sum are the most preferred.
-                                    items:
-                                      description: An empty preferred scheduling term
-                                        matches all objects with implicit weight 0
-                                        (i.e. it's a no-op). A null preferred scheduling
-                                        term matches no objects (i.e. is also a no-op).
-                                      properties:
-                                        preference:
-                                          description: A node selector term, associated
-                                            with the corresponding weight.
-                                          properties:
-                                            matchExpressions:
-                                              description: A list of node selector
-                                                requirements by node's labels.
-                                              items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: The label key that
-                                                      the selector applies to.
-                                                    type: string
-                                                  operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
-                                                    type: string
-                                                  values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              description: A list of node selector
-                                                requirements by node's fields.
-                                              items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: The label key that
-                                                      the selector applies to.
-                                                    type: string
-                                                  operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
-                                                    type: string
-                                                  values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        weight:
-                                          description: Weight associated with matching
-                                            the corresponding nodeSelectorTerm, in
-                                            the range 1-100.
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - preference
-                                      - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified
-                                      by this field are not met at scheduling time,
-                                      the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this
-                                      field cease to be met at some point during pod
-                                      execution (e.g. due to an update), the system
-                                      may or may not try to eventually evict the pod
-                                      from its node.
-                                    properties:
-                                      nodeSelectorTerms:
-                                        description: Required. A list of node selector
-                                          terms. The terms are ORed.
-                                        items:
-                                          description: A null or empty node selector
-                                            term matches no objects. The requirements
-                                            of them are ANDed. The TopologySelectorTerm
-                                            type implements a subset of the NodeSelectorTerm.
-                                          properties:
-                                            matchExpressions:
-                                              description: A list of node selector
-                                                requirements by node's labels.
-                                              items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: The label key that
-                                                      the selector applies to.
-                                                    type: string
-                                                  operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
-                                                    type: string
-                                                  values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchFields:
-                                              description: A list of node selector
-                                                requirements by node's fields.
-                                              items:
-                                                description: A node selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: The label key that
-                                                      the selector applies to.
-                                                    type: string
-                                                  operator:
-                                                    description: Represents a key's
-                                                      relationship to a set of values.
-                                                      Valid operators are In, NotIn,
-                                                      Exists, DoesNotExist. Gt, and
-                                                      Lt.
-                                                    type: string
-                                                  values:
-                                                    description: An array of string
-                                                      values. If the operator is In
-                                                      or NotIn, the values array must
-                                                      be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      If the operator is Gt or Lt,
-                                                      the values array must have a
-                                                      single element, which will be
-                                                      interpreted as an integer. This
-                                                      array is replaced during a strategic
-                                                      merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                          type: object
-                                        type: array
-                                    required:
-                                    - nodeSelectorTerms
-                                    type: object
-                                type: object
-                              podAffinity:
-                                description: Describes pod affinity scheduling rules
-                                  (e.g. co-locate this pod in the same node, zone,
-                                  etc. as some other pod(s)).
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
-                                      pods to nodes that satisfy the affinity expressions
-                                      specified by this field, but it may choose a
-                                      node that violates one or more of the expressions.
-                                      The node that is most preferred is the one with
-                                      the greatest sum of weights, i.e. for each node
-                                      that meets all of the scheduling requirements
-                                      (resource request, requiredDuringScheduling
-                                      affinity expressions, etc.), compute a sum by
-                                      iterating through the elements of this field
-                                      and adding "weight" to the sum if the node has
-                                      pods which matches the corresponding podAffinityTerm;
-                                      the node(s) with the highest sum are the most
-                                      preferred.
-                                    items:
-                                      description: The weights of all of the matched
-                                        WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
-                                      properties:
-                                        podAffinityTerm:
-                                          description: Required. A pod affinity term,
-                                            associated with the corresponding weight.
-                                          properties:
-                                            labelSelector:
-                                              description: A label query over a set
-                                                of resources, in this case pods.
-                                              properties:
-                                                matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
-                                                  items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
-                                                    properties:
-                                                      key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
-                                                        type: string
-                                                      operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
-                                                        type: string
-                                                      values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              description: namespaces specifies which
-                                                namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
-                                              type: string
-                                          required:
-                                          - topologyKey
-                                          type: object
-                                        weight:
-                                          description: weight associated with matching
-                                            the corresponding podAffinityTerm, in
-                                            the range 1-100.
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - podAffinityTerm
-                                      - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the affinity requirements specified
-                                      by this field are not met at scheduling time,
-                                      the pod will not be scheduled onto the node.
-                                      If the affinity requirements specified by this
-                                      field cease to be met at some point during pod
-                                      execution (e.g. due to a pod label update),
-                                      the system may or may not try to eventually
-                                      evict the pod from its node. When there are
-                                      multiple elements, the lists of nodes corresponding
-                                      to each podAffinityTerm are intersected, i.e.
-                                      all terms must be satisfied.
-                                    items:
-                                      description: Defines a set of pods (namely those
-                                        matching the labelSelector relative to the
-                                        given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity)
-                                        with, where co-located is defined as running
-                                        on a node whose value of the label with key
-                                        <topologyKey> matches that of any node on
-                                        which a pod of the set of pods is running
-                                      properties:
-                                        labelSelector:
-                                          description: A label query over a set of
-                                            resources, in this case pods.
-                                          properties:
-                                            matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
-                                              items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
-                                                    type: string
-                                                  operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
-                                                    type: string
-                                                  values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          description: namespaces specifies which
-                                            namespaces the labelSelector applies to
-                                            (matches against); null or empty list
-                                            means "this pod's namespace"
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                              podAntiAffinity:
-                                description: Describes pod anti-affinity scheduling
-                                  rules (e.g. avoid putting this pod in the same node,
-                                  zone, etc. as some other pod(s)).
-                                properties:
-                                  preferredDuringSchedulingIgnoredDuringExecution:
-                                    description: The scheduler will prefer to schedule
-                                      pods to nodes that satisfy the anti-affinity
-                                      expressions specified by this field, but it
-                                      may choose a node that violates one or more
-                                      of the expressions. The node that is most preferred
-                                      is the one with the greatest sum of weights,
-                                      i.e. for each node that meets all of the scheduling
-                                      requirements (resource request, requiredDuringScheduling
-                                      anti-affinity expressions, etc.), compute a
-                                      sum by iterating through the elements of this
-                                      field and adding "weight" to the sum if the
-                                      node has pods which matches the corresponding
-                                      podAffinityTerm; the node(s) with the highest
-                                      sum are the most preferred.
-                                    items:
-                                      description: The weights of all of the matched
-                                        WeightedPodAffinityTerm fields are added per-node
-                                        to find the most preferred node(s)
-                                      properties:
-                                        podAffinityTerm:
-                                          description: Required. A pod affinity term,
-                                            associated with the corresponding weight.
-                                          properties:
-                                            labelSelector:
-                                              description: A label query over a set
-                                                of resources, in this case pods.
-                                              properties:
-                                                matchExpressions:
-                                                  description: matchExpressions is
-                                                    a list of label selector requirements.
-                                                    The requirements are ANDed.
-                                                  items:
-                                                    description: A label selector
-                                                      requirement is a selector that
-                                                      contains values, a key, and
-                                                      an operator that relates the
-                                                      key and values.
-                                                    properties:
-                                                      key:
-                                                        description: key is the label
-                                                          key that the selector applies
-                                                          to.
-                                                        type: string
-                                                      operator:
-                                                        description: operator represents
-                                                          a key's relationship to
-                                                          a set of values. Valid operators
-                                                          are In, NotIn, Exists and
-                                                          DoesNotExist.
-                                                        type: string
-                                                      values:
-                                                        description: values is an
-                                                          array of string values.
-                                                          If the operator is In or
-                                                          NotIn, the values array
-                                                          must be non-empty. If the
-                                                          operator is Exists or DoesNotExist,
-                                                          the values array must be
-                                                          empty. This array is replaced
-                                                          during a strategic merge
-                                                          patch.
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    required:
-                                                    - key
-                                                    - operator
-                                                    type: object
-                                                  type: array
-                                                matchLabels:
-                                                  additionalProperties:
-                                                    type: string
-                                                  description: matchLabels is a map
-                                                    of {key,value} pairs. A single
-                                                    {key,value} in the matchLabels
-                                                    map is equivalent to an element
-                                                    of matchExpressions, whose key
-                                                    field is "key", the operator is
-                                                    "In", and the values array contains
-                                                    only "value". The requirements
-                                                    are ANDed.
-                                                  type: object
-                                              type: object
-                                            namespaces:
-                                              description: namespaces specifies which
-                                                namespaces the labelSelector applies
-                                                to (matches against); null or empty
-                                                list means "this pod's namespace"
-                                              items:
-                                                type: string
-                                              type: array
-                                            topologyKey:
-                                              description: This pod should be co-located
-                                                (affinity) or not co-located (anti-affinity)
-                                                with the pods matching the labelSelector
-                                                in the specified namespaces, where
-                                                co-located is defined as running on
-                                                a node whose value of the label with
-                                                key topologyKey matches that of any
-                                                node on which any of the selected
-                                                pods is running. Empty topologyKey
-                                                is not allowed.
-                                              type: string
-                                          required:
-                                          - topologyKey
-                                          type: object
-                                        weight:
-                                          description: weight associated with matching
-                                            the corresponding podAffinityTerm, in
-                                            the range 1-100.
-                                          format: int32
-                                          type: integer
-                                      required:
-                                      - podAffinityTerm
-                                      - weight
-                                      type: object
-                                    type: array
-                                  requiredDuringSchedulingIgnoredDuringExecution:
-                                    description: If the anti-affinity requirements
-                                      specified by this field are not met at scheduling
-                                      time, the pod will not be scheduled onto the
-                                      node. If the anti-affinity requirements specified
-                                      by this field cease to be met at some point
-                                      during pod execution (e.g. due to a pod label
-                                      update), the system may or may not try to eventually
-                                      evict the pod from its node. When there are
-                                      multiple elements, the lists of nodes corresponding
-                                      to each podAffinityTerm are intersected, i.e.
-                                      all terms must be satisfied.
-                                    items:
-                                      description: Defines a set of pods (namely those
-                                        matching the labelSelector relative to the
-                                        given namespace(s)) that this pod should be
-                                        co-located (affinity) or not co-located (anti-affinity)
-                                        with, where co-located is defined as running
-                                        on a node whose value of the label with key
-                                        <topologyKey> matches that of any node on
-                                        which a pod of the set of pods is running
-                                      properties:
-                                        labelSelector:
-                                          description: A label query over a set of
-                                            resources, in this case pods.
-                                          properties:
-                                            matchExpressions:
-                                              description: matchExpressions is a list
-                                                of label selector requirements. The
-                                                requirements are ANDed.
-                                              items:
-                                                description: A label selector requirement
-                                                  is a selector that contains values,
-                                                  a key, and an operator that relates
-                                                  the key and values.
-                                                properties:
-                                                  key:
-                                                    description: key is the label
-                                                      key that the selector applies
-                                                      to.
-                                                    type: string
-                                                  operator:
-                                                    description: operator represents
-                                                      a key's relationship to a set
-                                                      of values. Valid operators are
-                                                      In, NotIn, Exists and DoesNotExist.
-                                                    type: string
-                                                  values:
-                                                    description: values is an array
-                                                      of string values. If the operator
-                                                      is In or NotIn, the values array
-                                                      must be non-empty. If the operator
-                                                      is Exists or DoesNotExist, the
-                                                      values array must be empty.
-                                                      This array is replaced during
-                                                      a strategic merge patch.
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              description: matchLabels is a map of
-                                                {key,value} pairs. A single {key,value}
-                                                in the matchLabels map is equivalent
-                                                to an element of matchExpressions,
-                                                whose key field is "key", the operator
-                                                is "In", and the values array contains
-                                                only "value". The requirements are
-                                                ANDed.
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          description: namespaces specifies which
-                                            namespaces the labelSelector applies to
-                                            (matches against); null or empty list
-                                            means "this pod's namespace"
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          description: This pod should be co-located
-                                            (affinity) or not co-located (anti-affinity)
-                                            with the pods matching the labelSelector
-                                            in the specified namespaces, where co-located
-                                            is defined as running on a node whose
-                                            value of the label with key topologyKey
-                                            matches that of any node on which any
-                                            of the selected pods is running. Empty
-                                            topologyKey is not allowed.
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    type: array
-                                type: object
-                            type: object
-                          automountServiceAccountToken:
-                            description: AutomountServiceAccountToken indicates whether
-                              a service account token should be automatically mounted.
-                            type: boolean
-                          dnsConfig:
-                            description: Specifies the DNS parameters of a pod. Parameters
-                              specified here will be merged to the generated DNS configuration
-                              based on DNSPolicy.
-                            properties:
-                              nameservers:
-                                description: A list of DNS name server IP addresses.
-                                  This will be appended to the base nameservers generated
-                                  from DNSPolicy. Duplicated nameservers will be removed.
-                                items:
-                                  type: string
-                                type: array
-                              options:
-                                description: A list of DNS resolver options. This
-                                  will be merged with the base options generated from
-                                  DNSPolicy. Duplicated entries will be removed. Resolution
-                                  options given in Options will override those that
-                                  appear in the base DNSPolicy.
-                                items:
-                                  description: PodDNSConfigOption defines DNS resolver
-                                    options of a pod.
-                                  properties:
-                                    name:
-                                      description: Required.
-                                      type: string
-                                    value:
-                                      type: string
-                                  type: object
-                                type: array
-                              searches:
-                                description: A list of DNS search domains for host-name
-                                  lookup. This will be appended to the base search
-                                  paths generated from DNSPolicy. Duplicated search
-                                  paths will be removed.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          dnsPolicy:
-                            description: Set DNS policy for the pod. Defaults to "ClusterFirst".
-                              Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
-                              'Default' or 'None'. DNS parameters given in DNSConfig
-                              will be merged with the policy selected with DNSPolicy.
-                              To have DNS options set along with hostNetwork, you
-                              have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
-                            type: string
-                          enableServiceLinks:
-                            description: 'EnableServiceLinks indicates whether information
-                              about services should be injected into pod''s environment
-                              variables, matching the syntax of Docker links. Optional:
-                              Defaults to true.'
-                            type: boolean
-                          ephemeralContainers:
-                            description: List of ephemeral containers run in this
-                              pod. Ephemeral containers may be run in an existing
-                              pod to perform user-initiated actions such as debugging.
-                              This list cannot be specified when creating a pod, and
-                              it cannot be modified by updating the pod spec. In order
-                              to add an ephemeral container to an existing pod, use
-                              the pod's ephemeralcontainers subresource. This field
-                              is alpha-level and is only honored by servers that enable
-                              the EphemeralContainers feature.
-                            items:
-                              description: An EphemeralContainer is a container that
-                                may be added temporarily to an existing pod for user-initiated
-                                activities such as debugging. Ephemeral containers
-                                have no resource or scheduling guarantees, and they
-                                will not be restarted when they exit or when a pod
-                                is removed or restarted. If an ephemeral container
-                                causes a pod to exceed its resource allocation, the
-                                pod may be evicted. Ephemeral containers may not be
-                                added by directly updating the pod spec. They must
-                                be added via the pod's ephemeralcontainers subresource,
-                                and they will appear in the pod spec once added. This
-                                is an alpha feature enabled by the EphemeralContainers
-                                feature flag.
-                              properties:
-                                args:
-                                  description: 'Arguments to the entrypoint. The docker
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. The $(VAR_NAME) syntax can
-                                    be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                                  items:
-                                    type: string
-                                  type: array
-                                command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The docker image''s ENTRYPOINT is used
-                                    if this is not provided. Variable references $(VAR_NAME)
-                                    are expanded using the container''s environment.
-                                    If a variable cannot be resolved, the reference
-                                    in the input string will be unchanged. The $(VAR_NAME)
-                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                                  items:
-                                    type: string
-                                  type: array
-                                env:
-                                  description: List of environment variables to set
-                                    in the container. Cannot be updated.
-                                  items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
-                                    properties:
-                                      name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
-                                        type: string
-                                      value:
-                                        description: 'Variable references $(VAR_NAME)
-                                          are expanded using the previous defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Defaults to
-                                          "".'
-                                        type: string
-                                      valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
-                                        properties:
-                                          configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
-                                            properties:
-                                              key:
-                                                description: The key to select.
-                                                type: string
-                                              name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
-                                                type: string
-                                              optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                          fieldRef:
-                                            description: 'Selects a field of the pod:
-                                              supports metadata.name, metadata.namespace,
-                                              metadata.labels, metadata.annotations,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
-                                            properties:
-                                              apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
-                                                type: string
-                                              fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
-                                            properties:
-                                              containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                description: 'Required: resource to
-                                                  select'
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                          secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
-                                            properties:
-                                              key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
-                                                type: string
-                                              name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
-                                                type: string
-                                              optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                        type: object
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
-                                envFrom:
-                                  description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
-                                  items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
-                                    properties:
-                                      configMapRef:
-                                        description: The ConfigMap to select from
-                                        properties:
-                                          name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
-                                            type: boolean
-                                        type: object
-                                      prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
-                                        type: string
-                                      secretRef:
-                                        description: The Secret to select from
-                                        properties:
-                                          name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret
-                                              must be defined
-                                            type: boolean
-                                        type: object
-                                    type: object
-                                  type: array
-                                image:
-                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
-                                  type: string
-                                imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                                  type: string
-                                lifecycle:
-                                  description: Lifecycle is not allowed for ephemeral
-                                    containers.
-                                  properties:
-                                    postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                                      properties:
-                                        exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
-                                          properties:
-                                            command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
-                                          properties:
-                                            host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
-                                              type: string
-                                            httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
-                                              items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
-                                                properties:
-                                                  name:
-                                                    description: The header field
-                                                      name
-                                                    type: string
-                                                  value:
-                                                    description: The header field
-                                                      value
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              description: Path to access on the HTTP
-                                                server.
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
-                                          properties:
-                                            host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                    preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The reason for termination
-                                        is passed to the handler. The Pod''s termination
-                                        grace period countdown begins before the PreStop
-                                        hooked is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period. Other management of the container
-                                        blocks until the hook completes or until the
-                                        termination grace period is reached. More
-                                        info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                                      properties:
-                                        exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
-                                          properties:
-                                            command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
-                                          properties:
-                                            host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
-                                              type: string
-                                            httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
-                                              items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
-                                                properties:
-                                                  name:
-                                                    description: The header field
-                                                      name
-                                                    type: string
-                                                  value:
-                                                    description: The header field
-                                                      value
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              description: Path to access on the HTTP
-                                                server.
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
-                                          properties:
-                                            host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                  type: object
-                                livenessProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
-                                  properties:
-                                    exec:
-                                      description: One and only one of the following
-                                        should be specified. Exec specifies the action
-                                        to take.
-                                      properties:
-                                        command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
-                                      properties:
-                                        host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
-                                          type: string
-                                        httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
-                                          items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
-                                            properties:
-                                              name:
-                                                description: The header field name
-                                                type: string
-                                              value:
-                                                description: The header field value
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          description: Path to access on the HTTP
-                                            server.
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
-                                      properties:
-                                        host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  description: Name of the ephemeral container specified
-                                    as a DNS_LABEL. This name must be unique among
-                                    all containers, init containers and ephemeral
-                                    containers.
-                                  type: string
-                                ports:
-                                  description: Ports are not allowed for ephemeral
-                                    containers.
-                                  items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
-                                    properties:
-                                      containerPort:
-                                        description: Number of port to expose on the
-                                          pod's IP address. This must be a valid port
-                                          number, 0 < x < 65536.
-                                        format: int32
-                                        type: integer
-                                      hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
-                                        type: string
-                                      hostPort:
-                                        description: Number of port to expose on the
-                                          host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
-                                          Most containers do not need this.
-                                        format: int32
-                                        type: integer
-                                      name:
-                                        description: If specified, this must be an
-                                          IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
-                                        type: string
-                                      protocol:
-                                        description: Protocol for port. Must be UDP,
-                                          TCP, or SCTP. Defaults to "TCP".
-                                        type: string
-                                    required:
-                                    - containerPort
-                                    type: object
-                                  type: array
-                                readinessProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
-                                  properties:
-                                    exec:
-                                      description: One and only one of the following
-                                        should be specified. Exec specifies the action
-                                        to take.
-                                      properties:
-                                        command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
-                                      properties:
-                                        host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
-                                          type: string
-                                        httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
-                                          items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
-                                            properties:
-                                              name:
-                                                description: The header field name
-                                                type: string
-                                              value:
-                                                description: The header field value
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          description: Path to access on the HTTP
-                                            server.
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
-                                      properties:
-                                        host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  description: Resources are not allowed for ephemeral
-                                    containers. Ephemeral containers use spare resources
-                                    already allocated to the pod.
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                      type: object
-                                  type: object
-                                securityContext:
-                                  description: SecurityContext is not allowed for
-                                    ephemeral containers.
-                                  properties:
-                                    allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
-                                        whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN'
-                                      type: boolean
-                                    capabilities:
-                                      description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime.
-                                      properties:
-                                        add:
-                                          description: Added capabilities
-                                          items:
-                                            description: Capability represent POSIX
-                                              capabilities type
-                                            type: string
-                                          type: array
-                                        drop:
-                                          description: Removed capabilities
-                                          items:
-                                            description: Capability represent POSIX
-                                              capabilities type
-                                            type: string
-                                          type: array
-                                      type: object
-                                    privileged:
-                                      description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false.
-                                      type: boolean
-                                    procMount:
-                                      description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled.
-                                      type: string
-                                    readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only
-                                        root filesystem. Default is false.
-                                      type: boolean
-                                    runAsGroup:
-                                      description: The GID to run the entrypoint of
-                                        the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      format: int64
-                                      type: integer
-                                    runAsNonRoot:
-                                      description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      type: boolean
-                                    runAsUser:
-                                      description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
-                                      format: int64
-                                      type: integer
-                                    seLinuxOptions:
-                                      description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      properties:
-                                        level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
-                                          type: string
-                                        role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
-                                          type: string
-                                        type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
-                                          type: string
-                                        user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
-                                          type: string
-                                      type: object
-                                    windowsOptions:
-                                      description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      properties:
-                                        gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field. This field is alpha-level and is
-                                            only honored by servers that enable the
-                                            WindowsGMSA feature flag.
-                                          type: string
-                                        gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
-                                            This field is alpha-level and is only
-                                            honored by servers that enable the WindowsGMSA
-                                            feature flag.
-                                          type: string
-                                        runAsUserName:
-                                          description: The UserName in Windows to
-                                            run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. This field is beta-level
-                                            and may be disabled with the WindowsRunAsUserName
-                                            feature flag.
-                                          type: string
-                                      type: object
-                                  type: object
-                                startupProbe:
-                                  description: Probes are not allowed for ephemeral
-                                    containers.
-                                  properties:
-                                    exec:
-                                      description: One and only one of the following
-                                        should be specified. Exec specifies the action
-                                        to take.
-                                      properties:
-                                        command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
-                                      properties:
-                                        host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
-                                          type: string
-                                        httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
-                                          items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
-                                            properties:
-                                              name:
-                                                description: The header field name
-                                                type: string
-                                              value:
-                                                description: The header field value
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          description: Path to access on the HTTP
-                                            server.
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
-                                      properties:
-                                        host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                stdin:
-                                  description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
-                                  type: boolean
-                                stdinOnce:
-                                  description: Whether the container runtime should
-                                    close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
-                                  type: boolean
-                                targetContainerName:
-                                  description: If set, the name of the container from
-                                    PodSpec that this ephemeral container targets.
-                                    The ephemeral container will be run in the namespaces
-                                    (IPC, PID, etc) of this container. If not set
-                                    then the ephemeral container is run in whatever
-                                    namespaces are shared for the pod. Note that the
-                                    container runtime must support this feature.
-                                  type: string
-                                terminationMessagePath:
-                                  description: 'Optional: Path at which the file to
-                                    which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
-                                  type: string
-                                terminationMessagePolicy:
-                                  description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
-                                  type: string
-                                tty:
-                                  description: Whether this container should allocate
-                                    a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
-                                  type: boolean
-                                volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container. This is a
-                                    beta feature.
-                                  items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
-                                    properties:
-                                      devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
-                                        type: string
-                                      name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
-                                        type: string
-                                    required:
-                                    - devicePath
-                                    - name
-                                    type: object
-                                  type: array
-                                volumeMounts:
-                                  description: Pod volumes to mount into the container's
-                                    filesystem. Cannot be updated.
-                                  items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
-                                    properties:
-                                      mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
-                                          not contain ':'.
-                                        type: string
-                                      mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
-                                        type: string
-                                      name:
-                                        description: This must match the Name of a
-                                          Volume.
-                                        type: string
-                                      readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
-                                        type: boolean
-                                      subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
-                                        type: string
-                                      subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
-                                        type: string
-                                    required:
-                                    - mountPath
-                                    - name
-                                    type: object
-                                  type: array
-                                workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          hostAliases:
-                            description: HostAliases is an optional list of hosts
-                              and IPs that will be injected into the pod's hosts file
-                              if specified. This is only valid for non-hostNetwork
-                              pods.
-                            items:
-                              description: HostAlias holds the mapping between IP
-                                and hostnames that will be injected as an entry in
-                                the pod's hosts file.
-                              properties:
-                                hostnames:
-                                  description: Hostnames for the above IP address.
-                                  items:
-                                    type: string
-                                  type: array
-                                ip:
-                                  description: IP address of the host file entry.
-                                  type: string
-                              type: object
-                            type: array
-                          hostIPC:
-                            description: 'Use the host''s ipc namespace. Optional:
-                              Default to false.'
-                            type: boolean
-                          hostNetwork:
-                            description: Host networking requested for this pod. Use
-                              the host's network namespace. If this option is set,
-                              the ports that will be used must be specified. Default
-                              to false.
-                            type: boolean
-                          hostPID:
-                            description: 'Use the host''s pid namespace. Optional:
-                              Default to false.'
-                            type: boolean
-                          hostname:
-                            description: Specifies the hostname of the Pod If not
-                              specified, the pod's hostname will be set to a system-defined
-                              value.
-                            type: string
-                          imagePullSecrets:
-                            description: 'ImagePullSecrets is an optional list of
-                              references to secrets in the same namespace to use for
-                              pulling any of the images used by this PodSpec. If specified,
-                              these secrets will be passed to individual puller implementations
-                              for them to use. For example, in the case of docker,
-                              only DockerConfig type secrets are honored. More info:
-                              https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
-                            items:
-                              description: LocalObjectReference contains enough information
-                                to let you locate the referenced object inside the
-                                same namespace.
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                              type: object
-                            type: array
-                          initContainers:
-                            description: 'List of initialization containers belonging
-                              to the pod. Init containers are executed in order prior
-                              to containers being started. If any init container fails,
-                              the pod is considered to have failed and is handled
-                              according to its restartPolicy. The name for an init
-                              container or normal container must be unique among all
-                              containers. Init containers may not have Lifecycle actions,
-                              Readiness probes, Liveness probes, or Startup probes.
-                              The resourceRequirements of an init container are taken
-                              into account during scheduling by finding the highest
-                              request/limit for each resource type, and then using
-                              the max of of that value or the sum of the normal containers.
-                              Limits are applied to init containers in a similar fashion.
-                              Init containers cannot currently be added or removed.
-                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
-                            items:
-                              description: A single application container that you
-                                want to run within a pod.
-                              properties:
-                                args:
-                                  description: 'Arguments to the entrypoint. The docker
-                                    image''s CMD is used if this is not provided.
-                                    Variable references $(VAR_NAME) are expanded using
-                                    the container''s environment. If a variable cannot
-                                    be resolved, the reference in the input string
-                                    will be unchanged. The $(VAR_NAME) syntax can
-                                    be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                                  items:
-                                    type: string
-                                  type: array
-                                command:
-                                  description: 'Entrypoint array. Not executed within
-                                    a shell. The docker image''s ENTRYPOINT is used
-                                    if this is not provided. Variable references $(VAR_NAME)
-                                    are expanded using the container''s environment.
-                                    If a variable cannot be resolved, the reference
-                                    in the input string will be unchanged. The $(VAR_NAME)
-                                    syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                    Escaped references will never be expanded, regardless
-                                    of whether the variable exists or not. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                                  items:
-                                    type: string
-                                  type: array
-                                env:
-                                  description: List of environment variables to set
-                                    in the container. Cannot be updated.
-                                  items:
-                                    description: EnvVar represents an environment
-                                      variable present in a Container.
-                                    properties:
-                                      name:
-                                        description: Name of the environment variable.
-                                          Must be a C_IDENTIFIER.
-                                        type: string
-                                      value:
-                                        description: 'Variable references $(VAR_NAME)
-                                          are expanded using the previous defined
-                                          environment variables in the container and
-                                          any service environment variables. If a
-                                          variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Defaults to
-                                          "".'
-                                        type: string
-                                      valueFrom:
-                                        description: Source for the environment variable's
-                                          value. Cannot be used if value is not empty.
-                                        properties:
-                                          configMapKeyRef:
-                                            description: Selects a key of a ConfigMap.
-                                            properties:
-                                              key:
-                                                description: The key to select.
-                                                type: string
-                                              name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
-                                                type: string
-                                              optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its key must be defined
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                          fieldRef:
-                                            description: 'Selects a field of the pod:
-                                              supports metadata.name, metadata.namespace,
-                                              metadata.labels, metadata.annotations,
-                                              spec.nodeName, spec.serviceAccountName,
-                                              status.hostIP, status.podIP, status.podIPs.'
-                                            properties:
-                                              apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
-                                                type: string
-                                              fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              limits.ephemeral-storage, requests.cpu,
-                                              requests.memory and requests.ephemeral-storage)
-                                              are currently supported.'
-                                            properties:
-                                              containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                description: 'Required: resource to
-                                                  select'
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                          secretKeyRef:
-                                            description: Selects a key of a secret
-                                              in the pod's namespace
-                                            properties:
-                                              key:
-                                                description: The key of the secret
-                                                  to select from.  Must be a valid
-                                                  secret key.
-                                                type: string
-                                              name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
-                                                type: string
-                                              optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
-                                                type: boolean
-                                            required:
-                                            - key
-                                            type: object
-                                        type: object
-                                    required:
-                                    - name
-                                    type: object
-                                  type: array
-                                envFrom:
-                                  description: List of sources to populate environment
-                                    variables in the container. The keys defined within
-                                    a source must be a C_IDENTIFIER. All invalid keys
-                                    will be reported as an event when the container
-                                    is starting. When a key exists in multiple sources,
-                                    the value associated with the last source will
-                                    take precedence. Values defined by an Env with
-                                    a duplicate key will take precedence. Cannot be
-                                    updated.
-                                  items:
-                                    description: EnvFromSource represents the source
-                                      of a set of ConfigMaps
-                                    properties:
-                                      configMapRef:
-                                        description: The ConfigMap to select from
-                                        properties:
-                                          name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the ConfigMap
-                                              must be defined
-                                            type: boolean
-                                        type: object
-                                      prefix:
-                                        description: An optional identifier to prepend
-                                          to each key in the ConfigMap. Must be a
-                                          C_IDENTIFIER.
-                                        type: string
-                                      secretRef:
-                                        description: The Secret to select from
-                                        properties:
-                                          name:
-                                            description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
-                                            type: string
-                                          optional:
-                                            description: Specify whether the Secret
-                                              must be defined
-                                            type: boolean
-                                        type: object
-                                    type: object
-                                  type: array
-                                image:
-                                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                                    This field is optional to allow higher level config
-                                    management to default or override container images
-                                    in workload controllers like Deployments and StatefulSets.'
-                                  type: string
-                                imagePullPolicy:
-                                  description: 'Image pull policy. One of Always,
-                                    Never, IfNotPresent. Defaults to Always if :latest
-                                    tag is specified, or IfNotPresent otherwise. Cannot
-                                    be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                                  type: string
-                                lifecycle:
-                                  description: Actions that the management system
-                                    should take in response to container lifecycle
-                                    events. Cannot be updated.
-                                  properties:
-                                    postStart:
-                                      description: 'PostStart is called immediately
-                                        after a container is created. If the handler
-                                        fails, the container is terminated and restarted
-                                        according to its restart policy. Other management
-                                        of the container blocks until the hook completes.
-                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                                      properties:
-                                        exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
-                                          properties:
-                                            command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
-                                          properties:
-                                            host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
-                                              type: string
-                                            httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
-                                              items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
-                                                properties:
-                                                  name:
-                                                    description: The header field
-                                                      name
-                                                    type: string
-                                                  value:
-                                                    description: The header field
-                                                      value
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              description: Path to access on the HTTP
-                                                server.
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
-                                          properties:
-                                            host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                    preStop:
-                                      description: 'PreStop is called immediately
-                                        before a container is terminated due to an
-                                        API request or management event such as liveness/startup
-                                        probe failure, preemption, resource contention,
-                                        etc. The handler is not called if the container
-                                        crashes or exits. The reason for termination
-                                        is passed to the handler. The Pod''s termination
-                                        grace period countdown begins before the PreStop
-                                        hooked is executed. Regardless of the outcome
-                                        of the handler, the container will eventually
-                                        terminate within the Pod''s termination grace
-                                        period. Other management of the container
-                                        blocks until the hook completes or until the
-                                        termination grace period is reached. More
-                                        info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
-                                      properties:
-                                        exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
-                                          properties:
-                                            command:
-                                              description: Command is the command
-                                                line to execute inside the container,
-                                                the working directory for the command  is
-                                                root ('/') in the container's filesystem.
-                                                The command is simply exec'd, it is
-                                                not run inside a shell, so traditional
-                                                shell instructions ('|', etc) won't
-                                                work. To use a shell, you need to
-                                                explicitly call out to that shell.
-                                                Exit status of 0 is treated as live/healthy
-                                                and non-zero is unhealthy.
-                                              items:
-                                                type: string
-                                              type: array
-                                          type: object
-                                        httpGet:
-                                          description: HTTPGet specifies the http
-                                            request to perform.
-                                          properties:
-                                            host:
-                                              description: Host name to connect to,
-                                                defaults to the pod IP. You probably
-                                                want to set "Host" in httpHeaders
-                                                instead.
-                                              type: string
-                                            httpHeaders:
-                                              description: Custom headers to set in
-                                                the request. HTTP allows repeated
-                                                headers.
-                                              items:
-                                                description: HTTPHeader describes
-                                                  a custom header to be used in HTTP
-                                                  probes
-                                                properties:
-                                                  name:
-                                                    description: The header field
-                                                      name
-                                                    type: string
-                                                  value:
-                                                    description: The header field
-                                                      value
-                                                    type: string
-                                                required:
-                                                - name
-                                                - value
-                                                type: object
-                                              type: array
-                                            path:
-                                              description: Path to access on the HTTP
-                                                server.
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Name or number of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                            scheme:
-                                              description: Scheme to use for connecting
-                                                to the host. Defaults to HTTP.
-                                              type: string
-                                          required:
-                                          - port
-                                          type: object
-                                        tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
-                                          properties:
-                                            host:
-                                              description: 'Optional: Host name to
-                                                connect to, defaults to the pod IP.'
-                                              type: string
-                                            port:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Number or name of the port
-                                                to access on the container. Number
-                                                must be in the range 1 to 65535. Name
-                                                must be an IANA_SVC_NAME.
-                                              x-kubernetes-int-or-string: true
-                                          required:
-                                          - port
-                                          type: object
-                                      type: object
-                                  type: object
-                                livenessProbe:
-                                  description: 'Periodic probe of container liveness.
-                                    Container will be restarted if the probe fails.
-                                    Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                  properties:
-                                    exec:
-                                      description: One and only one of the following
-                                        should be specified. Exec specifies the action
-                                        to take.
-                                      properties:
-                                        command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
-                                      properties:
-                                        host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
-                                          type: string
-                                        httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
-                                          items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
-                                            properties:
-                                              name:
-                                                description: The header field name
-                                                type: string
-                                              value:
-                                                description: The header field value
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          description: Path to access on the HTTP
-                                            server.
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
-                                      properties:
-                                        host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                name:
-                                  description: Name of the container specified as
-                                    a DNS_LABEL. Each container in a pod must have
-                                    a unique name (DNS_LABEL). Cannot be updated.
-                                  type: string
-                                ports:
-                                  description: List of ports to expose from the container.
-                                    Exposing a port here gives the system additional
-                                    information about the network connections a container
-                                    uses, but is primarily informational. Not specifying
-                                    a port here DOES NOT prevent that port from being
-                                    exposed. Any port which is listening on the default
-                                    "0.0.0.0" address inside a container will be accessible
-                                    from the network. Cannot be updated.
-                                  items:
-                                    description: ContainerPort represents a network
-                                      port in a single container.
-                                    properties:
-                                      containerPort:
-                                        description: Number of port to expose on the
-                                          pod's IP address. This must be a valid port
-                                          number, 0 < x < 65536.
-                                        format: int32
-                                        type: integer
-                                      hostIP:
-                                        description: What host IP to bind the external
-                                          port to.
-                                        type: string
-                                      hostPort:
-                                        description: Number of port to expose on the
-                                          host. If specified, this must be a valid
-                                          port number, 0 < x < 65536. If HostNetwork
-                                          is specified, this must match ContainerPort.
-                                          Most containers do not need this.
-                                        format: int32
-                                        type: integer
-                                      name:
-                                        description: If specified, this must be an
-                                          IANA_SVC_NAME and unique within the pod.
-                                          Each named port in a pod must have a unique
-                                          name. Name for the port that can be referred
-                                          to by services.
-                                        type: string
-                                      protocol:
-                                        description: Protocol for port. Must be UDP,
-                                          TCP, or SCTP. Defaults to "TCP".
-                                        type: string
-                                    required:
-                                    - containerPort
-                                    type: object
-                                  type: array
-                                readinessProbe:
-                                  description: 'Periodic probe of container service
-                                    readiness. Container will be removed from service
-                                    endpoints if the probe fails. Cannot be updated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                  properties:
-                                    exec:
-                                      description: One and only one of the following
-                                        should be specified. Exec specifies the action
-                                        to take.
-                                      properties:
-                                        command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
-                                      properties:
-                                        host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
-                                          type: string
-                                        httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
-                                          items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
-                                            properties:
-                                              name:
-                                                description: The header field name
-                                                type: string
-                                              value:
-                                                description: The header field value
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          description: Path to access on the HTTP
-                                            server.
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
-                                      properties:
-                                        host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                resources:
-                                  description: 'Compute Resources required by this
-                                    container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                      type: object
-                                  type: object
-                                securityContext:
-                                  description: 'Security options the pod should run
-                                    with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
-                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
-                                  properties:
-                                    allowPrivilegeEscalation:
-                                      description: 'AllowPrivilegeEscalation controls
-                                        whether a process can gain more privileges
-                                        than its parent process. This bool directly
-                                        controls if the no_new_privs flag will be
-                                        set on the container process. AllowPrivilegeEscalation
-                                        is true always when the container is: 1) run
-                                        as Privileged 2) has CAP_SYS_ADMIN'
-                                      type: boolean
-                                    capabilities:
-                                      description: The capabilities to add/drop when
-                                        running containers. Defaults to the default
-                                        set of capabilities granted by the container
-                                        runtime.
-                                      properties:
-                                        add:
-                                          description: Added capabilities
-                                          items:
-                                            description: Capability represent POSIX
-                                              capabilities type
-                                            type: string
-                                          type: array
-                                        drop:
-                                          description: Removed capabilities
-                                          items:
-                                            description: Capability represent POSIX
-                                              capabilities type
-                                            type: string
-                                          type: array
-                                      type: object
-                                    privileged:
-                                      description: Run container in privileged mode.
-                                        Processes in privileged containers are essentially
-                                        equivalent to root on the host. Defaults to
-                                        false.
-                                      type: boolean
-                                    procMount:
-                                      description: procMount denotes the type of proc
-                                        mount to use for the containers. The default
-                                        is DefaultProcMount which uses the container
-                                        runtime defaults for readonly paths and masked
-                                        paths. This requires the ProcMountType feature
-                                        flag to be enabled.
-                                      type: string
-                                    readOnlyRootFilesystem:
-                                      description: Whether this container has a read-only
-                                        root filesystem. Default is false.
-                                      type: boolean
-                                    runAsGroup:
-                                      description: The GID to run the entrypoint of
-                                        the container process. Uses runtime default
-                                        if unset. May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      format: int64
-                                      type: integer
-                                    runAsNonRoot:
-                                      description: Indicates that the container must
-                                        run as a non-root user. If true, the Kubelet
-                                        will validate the image at runtime to ensure
-                                        that it does not run as UID 0 (root) and fail
-                                        to start the container if it does. If unset
-                                        or false, no such validation will be performed.
-                                        May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      type: boolean
-                                    runAsUser:
-                                      description: The UID to run the entrypoint of
-                                        the container process. Defaults to user specified
-                                        in image metadata if unspecified. May also
-                                        be set in PodSecurityContext.  If set in both
-                                        SecurityContext and PodSecurityContext, the
-                                        value specified in SecurityContext takes precedence.
-                                      format: int64
-                                      type: integer
-                                    seLinuxOptions:
-                                      description: The SELinux context to be applied
-                                        to the container. If unspecified, the container
-                                        runtime will allocate a random SELinux context
-                                        for each container.  May also be set in PodSecurityContext.  If
-                                        set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      properties:
-                                        level:
-                                          description: Level is SELinux level label
-                                            that applies to the container.
-                                          type: string
-                                        role:
-                                          description: Role is a SELinux role label
-                                            that applies to the container.
-                                          type: string
-                                        type:
-                                          description: Type is a SELinux type label
-                                            that applies to the container.
-                                          type: string
-                                        user:
-                                          description: User is a SELinux user label
-                                            that applies to the container.
-                                          type: string
-                                      type: object
-                                    windowsOptions:
-                                      description: The Windows specific settings applied
-                                        to all containers. If unspecified, the options
-                                        from the PodSecurityContext will be used.
-                                        If set in both SecurityContext and PodSecurityContext,
-                                        the value specified in SecurityContext takes
-                                        precedence.
-                                      properties:
-                                        gmsaCredentialSpec:
-                                          description: GMSACredentialSpec is where
-                                            the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                            inlines the contents of the GMSA credential
-                                            spec named by the GMSACredentialSpecName
-                                            field. This field is alpha-level and is
-                                            only honored by servers that enable the
-                                            WindowsGMSA feature flag.
-                                          type: string
-                                        gmsaCredentialSpecName:
-                                          description: GMSACredentialSpecName is the
-                                            name of the GMSA credential spec to use.
-                                            This field is alpha-level and is only
-                                            honored by servers that enable the WindowsGMSA
-                                            feature flag.
-                                          type: string
-                                        runAsUserName:
-                                          description: The UserName in Windows to
-                                            run the entrypoint of the container process.
-                                            Defaults to the user specified in image
-                                            metadata if unspecified. May also be set
-                                            in PodSecurityContext. If set in both
-                                            SecurityContext and PodSecurityContext,
-                                            the value specified in SecurityContext
-                                            takes precedence. This field is beta-level
-                                            and may be disabled with the WindowsRunAsUserName
-                                            feature flag.
-                                          type: string
-                                      type: object
-                                  type: object
-                                startupProbe:
-                                  description: 'StartupProbe indicates that the Pod
-                                    has successfully initialized. If specified, no
-                                    other probes are executed until this completes
-                                    successfully. If this probe fails, the Pod will
-                                    be restarted, just as if the livenessProbe failed.
-                                    This can be used to provide different probe parameters
-                                    at the beginning of a Pod''s lifecycle, when it
-                                    might take a long time to load data or warm a
-                                    cache, than during steady-state operation. This
-                                    cannot be updated. This is an alpha feature enabled
-                                    by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                  properties:
-                                    exec:
-                                      description: One and only one of the following
-                                        should be specified. Exec specifies the action
-                                        to take.
-                                      properties:
-                                        command:
-                                          description: Command is the command line
-                                            to execute inside the container, the working
-                                            directory for the command  is root ('/')
-                                            in the container's filesystem. The command
-                                            is simply exec'd, it is not run inside
-                                            a shell, so traditional shell instructions
-                                            ('|', etc) won't work. To use a shell,
-                                            you need to explicitly call out to that
-                                            shell. Exit status of 0 is treated as
-                                            live/healthy and non-zero is unhealthy.
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    failureThreshold:
-                                      description: Minimum consecutive failures for
-                                        the probe to be considered failed after having
-                                        succeeded. Defaults to 3. Minimum value is
-                                        1.
-                                      format: int32
-                                      type: integer
-                                    httpGet:
-                                      description: HTTPGet specifies the http request
-                                        to perform.
-                                      properties:
-                                        host:
-                                          description: Host name to connect to, defaults
-                                            to the pod IP. You probably want to set
-                                            "Host" in httpHeaders instead.
-                                          type: string
-                                        httpHeaders:
-                                          description: Custom headers to set in the
-                                            request. HTTP allows repeated headers.
-                                          items:
-                                            description: HTTPHeader describes a custom
-                                              header to be used in HTTP probes
-                                            properties:
-                                              name:
-                                                description: The header field name
-                                                type: string
-                                              value:
-                                                description: The header field value
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          description: Path to access on the HTTP
-                                            server.
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Name or number of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          description: Scheme to use for connecting
-                                            to the host. Defaults to HTTP.
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    initialDelaySeconds:
-                                      description: 'Number of seconds after the container
-                                        has started before liveness probes are initiated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                    periodSeconds:
-                                      description: How often (in seconds) to perform
-                                        the probe. Default to 10 seconds. Minimum
-                                        value is 1.
-                                      format: int32
-                                      type: integer
-                                    successThreshold:
-                                      description: Minimum consecutive successes for
-                                        the probe to be considered successful after
-                                        having failed. Defaults to 1. Must be 1 for
-                                        liveness and startup. Minimum value is 1.
-                                      format: int32
-                                      type: integer
-                                    tcpSocket:
-                                      description: 'TCPSocket specifies an action
-                                        involving a TCP port. TCP hooks not yet supported
-                                        TODO: implement a realistic TCP lifecycle
-                                        hook'
-                                      properties:
-                                        host:
-                                          description: 'Optional: Host name to connect
-                                            to, defaults to the pod IP.'
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          description: Number or name of the port
-                                            to access on the container. Number must
-                                            be in the range 1 to 65535. Name must
-                                            be an IANA_SVC_NAME.
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                    timeoutSeconds:
-                                      description: 'Number of seconds after which
-                                        the probe times out. Defaults to 1 second.
-                                        Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                stdin:
-                                  description: Whether this container should allocate
-                                    a buffer for stdin in the container runtime. If
-                                    this is not set, reads from stdin in the container
-                                    will always result in EOF. Default is false.
-                                  type: boolean
-                                stdinOnce:
-                                  description: Whether the container runtime should
-                                    close the stdin channel after it has been opened
-                                    by a single attach. When stdin is true the stdin
-                                    stream will remain open across multiple attach
-                                    sessions. If stdinOnce is set to true, stdin is
-                                    opened on container start, is empty until the
-                                    first client attaches to stdin, and then remains
-                                    open and accepts data until the client disconnects,
-                                    at which time stdin is closed and remains closed
-                                    until the container is restarted. If this flag
-                                    is false, a container processes that reads from
-                                    stdin will never receive an EOF. Default is false
-                                  type: boolean
-                                terminationMessagePath:
-                                  description: 'Optional: Path at which the file to
-                                    which the container''s termination message will
-                                    be written is mounted into the container''s filesystem.
-                                    Message written is intended to be brief final
-                                    status, such as an assertion failure message.
-                                    Will be truncated by the node if greater than
-                                    4096 bytes. The total message length across all
-                                    containers will be limited to 12kb. Defaults to
-                                    /dev/termination-log. Cannot be updated.'
-                                  type: string
-                                terminationMessagePolicy:
-                                  description: Indicate how the termination message
-                                    should be populated. File will use the contents
-                                    of terminationMessagePath to populate the container
-                                    status message on both success and failure. FallbackToLogsOnError
-                                    will use the last chunk of container log output
-                                    if the termination message file is empty and the
-                                    container exited with an error. The log output
-                                    is limited to 2048 bytes or 80 lines, whichever
-                                    is smaller. Defaults to File. Cannot be updated.
-                                  type: string
-                                tty:
-                                  description: Whether this container should allocate
-                                    a TTY for itself, also requires 'stdin' to be
-                                    true. Default is false.
-                                  type: boolean
-                                volumeDevices:
-                                  description: volumeDevices is the list of block
-                                    devices to be used by the container. This is a
-                                    beta feature.
-                                  items:
-                                    description: volumeDevice describes a mapping
-                                      of a raw block device within a container.
-                                    properties:
-                                      devicePath:
-                                        description: devicePath is the path inside
-                                          of the container that the device will be
-                                          mapped to.
-                                        type: string
-                                      name:
-                                        description: name must match the name of a
-                                          persistentVolumeClaim in the pod
-                                        type: string
-                                    required:
-                                    - devicePath
-                                    - name
-                                    type: object
-                                  type: array
-                                volumeMounts:
-                                  description: Pod volumes to mount into the container's
-                                    filesystem. Cannot be updated.
-                                  items:
-                                    description: VolumeMount describes a mounting
-                                      of a Volume within a container.
-                                    properties:
-                                      mountPath:
-                                        description: Path within the container at
-                                          which the volume should be mounted.  Must
-                                          not contain ':'.
-                                        type: string
-                                      mountPropagation:
-                                        description: mountPropagation determines how
-                                          mounts are propagated from the host to container
-                                          and the other way around. When not set,
-                                          MountPropagationNone is used. This field
-                                          is beta in 1.10.
-                                        type: string
-                                      name:
-                                        description: This must match the Name of a
-                                          Volume.
-                                        type: string
-                                      readOnly:
-                                        description: Mounted read-only if true, read-write
-                                          otherwise (false or unspecified). Defaults
-                                          to false.
-                                        type: boolean
-                                      subPath:
-                                        description: Path within the volume from which
-                                          the container's volume should be mounted.
-                                          Defaults to "" (volume's root).
-                                        type: string
-                                      subPathExpr:
-                                        description: Expanded path within the volume
-                                          from which the container's volume should
-                                          be mounted. Behaves similarly to SubPath
-                                          but environment variable references $(VAR_NAME)
-                                          are expanded using the container's environment.
-                                          Defaults to "" (volume's root). SubPathExpr
-                                          and SubPath are mutually exclusive.
-                                        type: string
-                                    required:
-                                    - mountPath
-                                    - name
-                                    type: object
-                                  type: array
-                                workingDir:
-                                  description: Container's working directory. If not
-                                    specified, the container runtime's default will
-                                    be used, which might be configured in the container
-                                    image. Cannot be updated.
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                          nodeName:
-                            description: NodeName is a request to schedule this pod
-                              onto a specific node. If it is non-empty, the scheduler
-                              simply schedules this pod onto that node, assuming that
-                              it fits resource requirements.
-                            type: string
-                          nodeSelector:
-                            additionalProperties:
-                              type: string
-                            description: 'NodeSelector is a selector which must be
-                              true for the pod to fit on a node. Selector which must
-                              match a node''s labels for the pod to be scheduled on
-                              that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                            type: object
-                          overhead:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Overhead represents the resource overhead
-                              associated with running a pod for a given RuntimeClass.
-                              This field will be autopopulated at admission time by
-                              the RuntimeClass admission controller. If the RuntimeClass
-                              admission controller is enabled, overhead must not be
-                              set in Pod create requests. The RuntimeClass admission
-                              controller will reject Pod create requests which have
-                              the overhead already set. If RuntimeClass is configured
-                              and selected in the PodSpec, Overhead will be set to
-                              the value defined in the corresponding RuntimeClass,
-                              otherwise it will remain unset and treated as zero.
-                              More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                              This field is alpha-level as of Kubernetes v1.16, and
-                              is only honored by servers that enable the PodOverhead
-                              feature.'
-                            type: object
-                          preemptionPolicy:
-                            description: PreemptionPolicy is the Policy for preempting
-                              pods with lower priority. One of Never, PreemptLowerPriority.
-                              Defaults to PreemptLowerPriority if unset. This field
-                              is alpha-level and is only honored by servers that enable
-                              the NonPreemptingPriority feature.
-                            type: string
-                          priority:
-                            description: The priority value. Various system components
-                              use this field to find the priority of the pod. When
-                              Priority Admission Controller is enabled, it prevents
-                              users from setting this field. The admission controller
-                              populates this field from PriorityClassName. The higher
-                              the value, the higher the priority.
-                            format: int32
-                            type: integer
-                          priorityClassName:
-                            description: If specified, indicates the pod's priority.
-                              "system-node-critical" and "system-cluster-critical"
-                              are two special keywords which indicate the highest
-                              priorities with the former being the highest priority.
-                              Any other name must be defined by creating a PriorityClass
-                              object with that name. If not specified, the pod priority
-                              will be default or zero if there is no default.
-                            type: string
-                          readinessGates:
-                            description: 'If specified, all readiness gates will be
-                              evaluated for pod readiness. A pod is ready when all
-                              its containers are ready AND all conditions specified
-                              in the readiness gates have status equal to "True" More
-                              info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
-                            items:
-                              description: PodReadinessGate contains the reference
-                                to a pod condition
-                              properties:
-                                conditionType:
-                                  description: ConditionType refers to a condition
-                                    in the pod's condition list with matching type.
-                                  type: string
-                              required:
-                              - conditionType
-                              type: object
-                            type: array
-                          restartPolicy:
-                            description: 'Restart policy for all containers within
-                              the pod. One of Always, OnFailure, Never. Default to
-                              Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
-                            type: string
-                          runtimeClassName:
-                            description: 'RuntimeClassName refers to a RuntimeClass
-                              object in the node.k8s.io group, which should be used
-                              to run this pod.  If no RuntimeClass resource matches
-                              the named class, the pod will not be run. If unset or
-                              empty, the "legacy" RuntimeClass will be used, which
-                              is an implicit class with an empty definition that uses
-                              the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                              This is a beta feature as of Kubernetes v1.14.'
-                            type: string
-                          schedulerName:
-                            description: If specified, the pod will be dispatched
-                              by specified scheduler. If not specified, the pod will
-                              be dispatched by default scheduler.
-                            type: string
-                          securityContext:
-                            description: 'SecurityContext holds pod-level security
-                              attributes and common container settings. Optional:
-                              Defaults to empty.  See type description for default
-                              values of each field.'
-                            properties:
-                              fsGroup:
-                                description: "A special supplemental group that applies
-                                  to all containers in a pod. Some volume types allow
-                                  the Kubelet to change the ownership of that volume
-                                  to be owned by the pod: \n 1. The owning GID will
-                                  be the FSGroup 2. The setgid bit is set (new files
-                                  created in the volume will be owned by FSGroup)
-                                  3. The permission bits are OR'd with rw-rw---- \n
-                                  If unset, the Kubelet will not modify the ownership
-                                  and permissions of any volume."
-                                format: int64
-                                type: integer
-                              runAsGroup:
-                                description: The GID to run the entrypoint of the
-                                  container process. Uses runtime default if unset.
-                                  May also be set in SecurityContext.  If set in both
-                                  SecurityContext and PodSecurityContext, the value
-                                  specified in SecurityContext takes precedence for
-                                  that container.
-                                format: int64
-                                type: integer
-                              runAsNonRoot:
-                                description: Indicates that the container must run
-                                  as a non-root user. If true, the Kubelet will validate
-                                  the image at runtime to ensure that it does not
-                                  run as UID 0 (root) and fail to start the container
-                                  if it does. If unset or false, no such validation
-                                  will be performed. May also be set in SecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
-                                type: boolean
-                              runAsUser:
-                                description: The UID to run the entrypoint of the
-                                  container process. Defaults to user specified in
-                                  image metadata if unspecified. May also be set in
-                                  SecurityContext.  If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence for that container.
-                                format: int64
-                                type: integer
-                              seLinuxOptions:
-                                description: The SELinux context to be applied to
-                                  all containers. If unspecified, the container runtime
-                                  will allocate a random SELinux context for each
-                                  container.  May also be set in SecurityContext.  If
-                                  set in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence
-                                  for that container.
-                                properties:
-                                  level:
-                                    description: Level is SELinux level label that
-                                      applies to the container.
-                                    type: string
-                                  role:
-                                    description: Role is a SELinux role label that
-                                      applies to the container.
-                                    type: string
-                                  type:
-                                    description: Type is a SELinux type label that
-                                      applies to the container.
-                                    type: string
-                                  user:
-                                    description: User is a SELinux user label that
-                                      applies to the container.
-                                    type: string
-                                type: object
-                              supplementalGroups:
-                                description: A list of groups applied to the first
-                                  process run in each container, in addition to the
-                                  container's primary GID.  If unspecified, no groups
-                                  will be added to any container.
-                                items:
-                                  format: int64
-                                  type: integer
-                                type: array
-                              sysctls:
-                                description: Sysctls hold a list of namespaced sysctls
-                                  used for the pod. Pods with unsupported sysctls
-                                  (by the container runtime) might fail to launch.
-                                items:
-                                  description: Sysctl defines a kernel parameter to
-                                    be set
-                                  properties:
-                                    name:
-                                      description: Name of a property to set
-                                      type: string
-                                    value:
-                                      description: Value of a property to set
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              windowsOptions:
-                                description: The Windows specific settings applied
-                                  to all containers. If unspecified, the options within
-                                  a container's SecurityContext will be used. If set
-                                  in both SecurityContext and PodSecurityContext,
-                                  the value specified in SecurityContext takes precedence.
-                                properties:
-                                  gmsaCredentialSpec:
-                                    description: GMSACredentialSpec is where the GMSA
-                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                      inlines the contents of the GMSA credential
-                                      spec named by the GMSACredentialSpecName field.
-                                      This field is alpha-level and is only honored
-                                      by servers that enable the WindowsGMSA feature
-                                      flag.
-                                    type: string
-                                  gmsaCredentialSpecName:
-                                    description: GMSACredentialSpecName is the name
-                                      of the GMSA credential spec to use. This field
-                                      is alpha-level and is only honored by servers
-                                      that enable the WindowsGMSA feature flag.
-                                    type: string
-                                  runAsUserName:
-                                    description: The UserName in Windows to run the
-                                      entrypoint of the container process. Defaults
-                                      to the user specified in image metadata if unspecified.
-                                      May also be set in PodSecurityContext. If set
-                                      in both SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext takes
-                                      precedence. This field is beta-level and may
-                                      be disabled with the WindowsRunAsUserName feature
-                                      flag.
-                                    type: string
-                                type: object
-                            type: object
-                          serviceAccount:
-                            description: 'DeprecatedServiceAccount is a depreciated
-                              alias for ServiceAccountName. Deprecated: Use serviceAccountName
-                              instead.'
-                            type: string
-                          serviceAccountName:
-                            description: 'ServiceAccountName is the name of the ServiceAccount
-                              to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
-                            type: string
-                          shareProcessNamespace:
-                            description: 'Share a single process namespace between
-                              all of the containers in a pod. When this is set containers
-                              will be able to view and signal processes from other
-                              containers in the same pod, and the first process in
-                              each container will not be assigned PID 1. HostPID and
-                              ShareProcessNamespace cannot both be set. Optional:
-                              Default to false.'
-                            type: boolean
-                          subdomain:
-                            description: If specified, the fully qualified Pod hostname
-                              will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                              domain>". If not specified, the pod will not have a
-                              domainname at all.
-                            type: string
-                          terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully. May be decreased in delete
-                              request. Value must be non-negative integer. The value
-                              zero indicates delete immediately. If this value is
-                              nil, the default grace period will be used instead.
-                              The grace period is the duration in seconds after the
-                              processes running in the pod are sent a termination
-                              signal and the time when the processes are forcibly
-                              halted with a kill signal. Set this value longer than
-                              the expected cleanup time for your process. Defaults
-                              to 30 seconds.
-                            format: int64
-                            type: integer
-                          tolerations:
-                            description: If specified, the pod's tolerations.
-                            items:
-                              description: The pod this Toleration is attached to
-                                tolerates any taint that matches the triple <key,value,effect>
-                                using the matching operator <operator>.
-                              properties:
-                                effect:
-                                  description: Effect indicates the taint effect to
-                                    match. Empty means match all taint effects. When
-                                    specified, allowed values are NoSchedule, PreferNoSchedule
-                                    and NoExecute.
-                                  type: string
-                                key:
-                                  description: Key is the taint key that the toleration
-                                    applies to. Empty means match all taint keys.
-                                    If the key is empty, operator must be Exists;
-                                    this combination means to match all values and
-                                    all keys.
-                                  type: string
-                                operator:
-                                  description: Operator represents a key's relationship
-                                    to the value. Valid operators are Exists and Equal.
-                                    Defaults to Equal. Exists is equivalent to wildcard
-                                    for value, so that a pod can tolerate all taints
-                                    of a particular category.
-                                  type: string
-                                tolerationSeconds:
-                                  description: TolerationSeconds represents the period
-                                    of time the toleration (which must be of effect
-                                    NoExecute, otherwise this field is ignored) tolerates
-                                    the taint. By default, it is not set, which means
-                                    tolerate the taint forever (do not evict). Zero
-                                    and negative values will be treated as 0 (evict
-                                    immediately) by the system.
-                                  format: int64
-                                  type: integer
-                                value:
-                                  description: Value is the taint value the toleration
-                                    matches to. If the operator is Exists, the value
-                                    should be empty, otherwise just a regular string.
-                                  type: string
-                              type: object
-                            type: array
-                          topologySpreadConstraints:
-                            description: TopologySpreadConstraints describes how a
-                              group of pods ought to spread across topology domains.
-                              Scheduler will schedule pods in a way which abides by
-                              the constraints. This field is alpha-level and is only
-                              honored by clusters that enables the EvenPodsSpread
-                              feature. All topologySpreadConstraints are ANDed.
-                            items:
-                              description: TopologySpreadConstraint specifies how
-                                to spread matching pods among the given topology.
-                              properties:
-                                labelSelector:
-                                  description: LabelSelector is used to find matching
-                                    pods. Pods that match this label selector are
-                                    counted to determine the number of pods in their
-                                    corresponding topology domain.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                maxSkew:
-                                  description: 'MaxSkew describes the degree to which
-                                    pods may be unevenly distributed. It''s the maximum
-                                    permitted difference between the number of matching
-                                    pods in any two topology domains of a given topology
-                                    type. For example, in a 3-zone cluster, MaxSkew
-                                    is set to 1, and pods with the same labelSelector
-                                    spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                    - if MaxSkew is 1, incoming pod can only be scheduled
-                                    to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                                    would make the ActualSkew(2-0) on zone1(zone2)
-                                    violate MaxSkew(1). - if MaxSkew is 2, incoming
-                                    pod can be scheduled onto any zone. It''s a required
-                                    field. Default value is 1 and 0 is not allowed.'
-                                  format: int32
-                                  type: integer
-                                topologyKey:
-                                  description: TopologyKey is the key of node labels.
-                                    Nodes that have a label with this key and identical
-                                    values are considered to be in the same topology.
-                                    We consider each <key, value> as a "bucket", and
-                                    try to put balanced number of pods into each bucket.
-                                    It's a required field.
-                                  type: string
-                                whenUnsatisfiable:
-                                  description: 'WhenUnsatisfiable indicates how to
-                                    deal with a pod if it doesn''t satisfy the spread
-                                    constraint. - DoNotSchedule (default) tells the
-                                    scheduler not to schedule it - ScheduleAnyway
-                                    tells the scheduler to still schedule it It''s
-                                    considered as "Unsatisfiable" if and only if placing
-                                    incoming pod on any topology violates "MaxSkew".
-                                    For example, in a 3-zone cluster, MaxSkew is set
-                                    to 1, and pods with the same labelSelector spread
-                                    as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
-                                    If WhenUnsatisfiable is set to DoNotSchedule,
-                                    incoming pod can only be scheduled to zone2(zone3)
-                                    to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3)
-                                    satisfies MaxSkew(1). In other words, the cluster
-                                    can still be imbalanced, but scheduler won''t
-                                    make it *more* imbalanced. It''s a required field.'
-                                  type: string
-                              required:
-                              - maxSkew
-                              - topologyKey
-                              - whenUnsatisfiable
-                              type: object
-                            type: array
-                          volumes:
-                            description: 'List of volumes that can be mounted by containers
-                              belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
-                            items:
-                              description: Volume represents a named volume in a pod
-                                that may be accessed by any container in the pod.
-                              properties:
-                                awsElasticBlockStore:
-                                  description: 'AWSElasticBlockStore represents an
-                                    AWS Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                  properties:
-                                    fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
-                                      type: string
-                                    partition:
-                                      description: 'The partition in the volume that
-                                        you want to mount. If omitted, the default
-                                        is to mount by volume name. Examples: For
-                                        volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty).'
-                                      format: int32
-                                      type: integer
-                                    readOnly:
-                                      description: 'Specify "true" to force and set
-                                        the ReadOnly property in VolumeMounts to "true".
-                                        If omitted, the default is "false". More info:
-                                        https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                      type: boolean
-                                    volumeID:
-                                      description: 'Unique ID of the persistent disk
-                                        resource in AWS (Amazon EBS volume). More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                                      type: string
-                                  required:
-                                  - volumeID
-                                  type: object
-                                azureDisk:
-                                  description: AzureDisk represents an Azure Data
-                                    Disk mount on the host and bind mount to the pod.
-                                  properties:
-                                    cachingMode:
-                                      description: 'Host Caching mode: None, Read
-                                        Only, Read Write.'
-                                      type: string
-                                    diskName:
-                                      description: The Name of the data disk in the
-                                        blob storage
-                                      type: string
-                                    diskURI:
-                                      description: The URI the data disk in the blob
-                                        storage
-                                      type: string
-                                    fsType:
-                                      description: Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
-                                      type: string
-                                    kind:
-                                      description: 'Expected values Shared: multiple
-                                        blob disks per storage account  Dedicated:
-                                        single blob disk per storage account  Managed:
-                                        azure managed data disk (only in managed availability
-                                        set). defaults to shared'
-                                      type: string
-                                    readOnly:
-                                      description: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
-                                      type: boolean
-                                  required:
-                                  - diskName
-                                  - diskURI
-                                  type: object
-                                azureFile:
-                                  description: AzureFile represents an Azure File
-                                    Service mount on the host and bind mount to the
-                                    pod.
-                                  properties:
-                                    readOnly:
-                                      description: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
-                                      type: boolean
-                                    secretName:
-                                      description: the name of secret that contains
-                                        Azure Storage Account Name and Key
-                                      type: string
-                                    shareName:
-                                      description: Share Name
-                                      type: string
-                                  required:
-                                  - secretName
-                                  - shareName
-                                  type: object
-                                cephfs:
-                                  description: CephFS represents a Ceph FS mount on
-                                    the host that shares a pod's lifetime
-                                  properties:
-                                    monitors:
-                                      description: 'Required: Monitors is a collection
-                                        of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                      items:
-                                        type: string
-                                      type: array
-                                    path:
-                                      description: 'Optional: Used as the mounted
-                                        root, rather than the full Ceph tree, default
-                                        is /'
-                                      type: string
-                                    readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                      type: boolean
-                                    secretFile:
-                                      description: 'Optional: SecretFile is the path
-                                        to key ring for User, default is /etc/ceph/user.secret
-                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                      type: string
-                                    secretRef:
-                                      description: 'Optional: SecretRef is reference
-                                        to the authentication secret for User, default
-                                        is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    user:
-                                      description: 'Optional: User is the rados user
-                                        name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                                      type: string
-                                  required:
-                                  - monitors
-                                  type: object
-                                cinder:
-                                  description: 'Cinder represents a cinder volume
-                                    attached and mounted on kubelets host machine.
-                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                  properties:
-                                    fsType:
-                                      description: 'Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Examples: "ext4", "xfs",
-                                        "ntfs". Implicitly inferred to be "ext4" if
-                                        unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                      type: string
-                                    readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                      type: boolean
-                                    secretRef:
-                                      description: 'Optional: points to a secret object
-                                        containing parameters used to connect to OpenStack.'
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    volumeID:
-                                      description: 'volume id used to identify the
-                                        volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                                      type: string
-                                  required:
-                                  - volumeID
-                                  type: object
-                                configMap:
-                                  description: ConfigMap represents a configMap that
-                                    should populate this volume
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the ConfigMap, the
-                                        volume setup will error unless it is marked
-                                        optional. Paths must be relative and may not
-                                        contain the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its keys must be defined
-                                      type: boolean
-                                  type: object
-                                csi:
-                                  description: CSI (Container Storage Interface) represents
-                                    storage that is handled by an external CSI driver
-                                    (Alpha feature).
-                                  properties:
-                                    driver:
-                                      description: Driver is the name of the CSI driver
-                                        that handles this volume. Consult with your
-                                        admin for the correct name as registered in
-                                        the cluster.
-                                      type: string
-                                    fsType:
-                                      description: Filesystem type to mount. Ex. "ext4",
-                                        "xfs", "ntfs". If not provided, the empty
-                                        value is passed to the associated CSI driver
-                                        which will determine the default filesystem
-                                        to apply.
-                                      type: string
-                                    nodePublishSecretRef:
-                                      description: NodePublishSecretRef is a reference
-                                        to the secret object containing sensitive
-                                        information to pass to the CSI driver to complete
-                                        the CSI NodePublishVolume and NodeUnpublishVolume
-                                        calls. This field is optional, and  may be
-                                        empty if no secret is required. If the secret
-                                        object contains more than one secret, all
-                                        secret references are passed.
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    readOnly:
-                                      description: Specifies a read-only configuration
-                                        for the volume. Defaults to false (read/write).
-                                      type: boolean
-                                    volumeAttributes:
-                                      additionalProperties:
-                                        type: string
-                                      description: VolumeAttributes stores driver-specific
-                                        properties that are passed to the CSI driver.
-                                        Consult your driver's documentation for supported
-                                        values.
-                                      type: object
-                                  required:
-                                  - driver
-                                  type: object
-                                downwardAPI:
-                                  description: DownwardAPI represents downward API
-                                    about the pod that should populate this volume
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: Items is a list of downward API
-                                        volume file
-                                      items:
-                                        description: DownwardAPIVolumeFile represents
-                                          information to create the file containing
-                                          the pod field
-                                        properties:
-                                          fieldRef:
-                                            description: 'Required: Selects a field
-                                              of the pod: only annotations, labels,
-                                              name and namespace are supported.'
-                                            properties:
-                                              apiVersion:
-                                                description: Version of the schema
-                                                  the FieldPath is written in terms
-                                                  of, defaults to "v1".
-                                                type: string
-                                              fieldPath:
-                                                description: Path of the field to
-                                                  select in the specified API version.
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: 'Required: Path is  the relative
-                                              path name of the file to be created.
-                                              Must not be absolute or contain the
-                                              ''..'' path. Must be utf-8 encoded.
-                                              The first item of the relative path
-                                              must not start with ''..'''
-                                            type: string
-                                          resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                              container: only resources limits and
-                                              requests (limits.cpu, limits.memory,
-                                              requests.cpu and requests.memory) are
-                                              currently supported.'
-                                            properties:
-                                              containerName:
-                                                description: 'Container name: required
-                                                  for volumes, optional for env vars'
-                                                type: string
-                                              divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                description: Specifies the output
-                                                  format of the exposed resources,
-                                                  defaults to "1"
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              resource:
-                                                description: 'Required: resource to
-                                                  select'
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                        required:
-                                        - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                emptyDir:
-                                  description: 'EmptyDir represents a temporary directory
-                                    that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                  properties:
-                                    medium:
-                                      description: 'What type of storage medium should
-                                        back this directory. The default is "" which
-                                        means to use the node''s default medium. Must
-                                        be an empty string (default) or Memory. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                                      type: string
-                                    sizeLimit:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      description: 'Total amount of local storage
-                                        required for this EmptyDir volume. The size
-                                        limit is also applicable for memory medium.
-                                        The maximum usage on memory medium EmptyDir
-                                        would be the minimum value between the SizeLimit
-                                        specified here and the sum of memory limits
-                                        of all containers in a pod. The default is
-                                        nil which means that the limit is undefined.
-                                        More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                  type: object
-                                fc:
-                                  description: FC represents a Fibre Channel resource
-                                    that is attached to a kubelet's host machine and
-                                    then exposed to the pod.
-                                  properties:
-                                    fsType:
-                                      description: 'Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
-                                      type: string
-                                    lun:
-                                      description: 'Optional: FC target lun number'
-                                      format: int32
-                                      type: integer
-                                    readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.'
-                                      type: boolean
-                                    targetWWNs:
-                                      description: 'Optional: FC target worldwide
-                                        names (WWNs)'
-                                      items:
-                                        type: string
-                                      type: array
-                                    wwids:
-                                      description: 'Optional: FC volume world wide
-                                        identifiers (wwids) Either wwids or combination
-                                        of targetWWNs and lun must be set, but not
-                                        both simultaneously.'
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                flexVolume:
-                                  description: FlexVolume represents a generic volume
-                                    resource that is provisioned/attached using an
-                                    exec based plugin.
-                                  properties:
-                                    driver:
-                                      description: Driver is the name of the driver
-                                        to use for this volume.
-                                      type: string
-                                    fsType:
-                                      description: Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        The default filesystem depends on FlexVolume
-                                        script.
-                                      type: string
-                                    options:
-                                      additionalProperties:
-                                        type: string
-                                      description: 'Optional: Extra command options
-                                        if any.'
-                                      type: object
-                                    readOnly:
-                                      description: 'Optional: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.'
-                                      type: boolean
-                                    secretRef:
-                                      description: 'Optional: SecretRef is reference
-                                        to the secret object containing sensitive
-                                        information to pass to the plugin scripts.
-                                        This may be empty if no secret object is specified.
-                                        If the secret object contains more than one
-                                        secret, all secrets are passed to the plugin
-                                        scripts.'
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                  required:
-                                  - driver
-                                  type: object
-                                flocker:
-                                  description: Flocker represents a Flocker volume
-                                    attached to a kubelet's host machine. This depends
-                                    on the Flocker control service being running
-                                  properties:
-                                    datasetName:
-                                      description: Name of the dataset stored as metadata
-                                        -> name on the dataset for Flocker should
-                                        be considered as deprecated
-                                      type: string
-                                    datasetUUID:
-                                      description: UUID of the dataset. This is unique
-                                        identifier of a Flocker dataset
-                                      type: string
-                                  type: object
-                                gcePersistentDisk:
-                                  description: 'GCEPersistentDisk represents a GCE
-                                    Disk resource that is attached to a kubelet''s
-                                    host machine and then exposed to the pod. More
-                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                  properties:
-                                    fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
-                                      type: string
-                                    partition:
-                                      description: 'The partition in the volume that
-                                        you want to mount. If omitted, the default
-                                        is to mount by volume name. Examples: For
-                                        volume /dev/sda1, you specify the partition
-                                        as "1". Similarly, the volume partition for
-                                        /dev/sda is "0" (or you can leave the property
-                                        empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                      format: int32
-                                      type: integer
-                                    pdName:
-                                      description: 'Unique name of the PD resource
-                                        in GCE. Used to identify the disk in GCE.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                      type: string
-                                    readOnly:
-                                      description: 'ReadOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                                      type: boolean
-                                  required:
-                                  - pdName
-                                  type: object
-                                gitRepo:
-                                  description: 'GitRepo represents a git repository
-                                    at a particular revision. DEPRECATED: GitRepo
-                                    is deprecated. To provision a container with a
-                                    git repo, mount an EmptyDir into an InitContainer
-                                    that clones the repo using git, then mount the
-                                    EmptyDir into the Pod''s container.'
-                                  properties:
-                                    directory:
-                                      description: Target directory name. Must not
-                                        contain or start with '..'.  If '.' is supplied,
-                                        the volume directory will be the git repository.  Otherwise,
-                                        if specified, the volume will contain the
-                                        git repository in the subdirectory with the
-                                        given name.
-                                      type: string
-                                    repository:
-                                      description: Repository URL
-                                      type: string
-                                    revision:
-                                      description: Commit hash for the specified revision.
-                                      type: string
-                                  required:
-                                  - repository
-                                  type: object
-                                glusterfs:
-                                  description: 'Glusterfs represents a Glusterfs mount
-                                    on the host that shares a pod''s lifetime. More
-                                    info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                                  properties:
-                                    endpoints:
-                                      description: 'EndpointsName is the endpoint
-                                        name that details Glusterfs topology. More
-                                        info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                      type: string
-                                    path:
-                                      description: 'Path is the Glusterfs volume path.
-                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                      type: string
-                                    readOnly:
-                                      description: 'ReadOnly here will force the Glusterfs
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                                      type: boolean
-                                  required:
-                                  - endpoints
-                                  - path
-                                  type: object
-                                hostPath:
-                                  description: 'HostPath represents a pre-existing
-                                    file or directory on the host machine that is
-                                    directly exposed to the container. This is generally
-                                    used for system agents or other privileged things
-                                    that are allowed to see the host machine. Most
-                                    containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                    --- TODO(jonesdl) We need to restrict who can
-                                    use host directory mounts and who can/can not
-                                    mount host directories as read/write.'
-                                  properties:
-                                    path:
-                                      description: 'Path of the directory on the host.
-                                        If the path is a symlink, it will follow the
-                                        link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                                      type: string
-                                    type:
-                                      description: 'Type for HostPath Volume Defaults
-                                        to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                                iscsi:
-                                  description: 'ISCSI represents an ISCSI Disk resource
-                                    that is attached to a kubelet''s host machine
-                                    and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                                  properties:
-                                    chapAuthDiscovery:
-                                      description: whether support iSCSI Discovery
-                                        CHAP authentication
-                                      type: boolean
-                                    chapAuthSession:
-                                      description: whether support iSCSI Session CHAP
-                                        authentication
-                                      type: boolean
-                                    fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
-                                      type: string
-                                    initiatorName:
-                                      description: Custom iSCSI Initiator Name. If
-                                        initiatorName is specified with iscsiInterface
-                                        simultaneously, new iSCSI interface <target
-                                        portal>:<volume name> will be created for
-                                        the connection.
-                                      type: string
-                                    iqn:
-                                      description: Target iSCSI Qualified Name.
-                                      type: string
-                                    iscsiInterface:
-                                      description: iSCSI Interface Name that uses
-                                        an iSCSI transport. Defaults to 'default'
-                                        (tcp).
-                                      type: string
-                                    lun:
-                                      description: iSCSI Target Lun number.
-                                      format: int32
-                                      type: integer
-                                    portals:
-                                      description: iSCSI Target Portal List. The portal
-                                        is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports
-                                        860 and 3260).
-                                      items:
-                                        type: string
-                                      type: array
-                                    readOnly:
-                                      description: ReadOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                      type: boolean
-                                    secretRef:
-                                      description: CHAP Secret for iSCSI target and
-                                        initiator authentication
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    targetPortal:
-                                      description: iSCSI Target Portal. The Portal
-                                        is either an IP or ip_addr:port if the port
-                                        is other than default (typically TCP ports
-                                        860 and 3260).
-                                      type: string
-                                  required:
-                                  - iqn
-                                  - lun
-                                  - targetPortal
-                                  type: object
-                                name:
-                                  description: 'Volume''s name. Must be a DNS_LABEL
-                                    and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                nfs:
-                                  description: 'NFS represents an NFS mount on the
-                                    host that shares a pod''s lifetime More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                  properties:
-                                    path:
-                                      description: 'Path that is exported by the NFS
-                                        server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                      type: string
-                                    readOnly:
-                                      description: 'ReadOnly here will force the NFS
-                                        export to be mounted with read-only permissions.
-                                        Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                      type: boolean
-                                    server:
-                                      description: 'Server is the hostname or IP address
-                                        of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                                      type: string
-                                  required:
-                                  - path
-                                  - server
-                                  type: object
-                                persistentVolumeClaim:
-                                  description: 'PersistentVolumeClaimVolumeSource
-                                    represents a reference to a PersistentVolumeClaim
-                                    in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                  properties:
-                                    claimName:
-                                      description: 'ClaimName is the name of a PersistentVolumeClaim
-                                        in the same namespace as the pod using this
-                                        volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                                      type: string
-                                    readOnly:
-                                      description: Will force the ReadOnly setting
-                                        in VolumeMounts. Default false.
-                                      type: boolean
-                                  required:
-                                  - claimName
-                                  type: object
-                                photonPersistentDisk:
-                                  description: PhotonPersistentDisk represents a PhotonController
-                                    persistent disk attached and mounted on kubelets
-                                    host machine
-                                  properties:
-                                    fsType:
-                                      description: Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
-                                      type: string
-                                    pdID:
-                                      description: ID that identifies Photon Controller
-                                        persistent disk
-                                      type: string
-                                  required:
-                                  - pdID
-                                  type: object
-                                portworxVolume:
-                                  description: PortworxVolume represents a portworx
-                                    volume attached and mounted on kubelets host machine
-                                  properties:
-                                    fsType:
-                                      description: FSType represents the filesystem
-                                        type to mount Must be a filesystem type supported
-                                        by the host operating system. Ex. "ext4",
-                                        "xfs". Implicitly inferred to be "ext4" if
-                                        unspecified.
-                                      type: string
-                                    readOnly:
-                                      description: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
-                                      type: boolean
-                                    volumeID:
-                                      description: VolumeID uniquely identifies a
-                                        Portworx volume
-                                      type: string
-                                  required:
-                                  - volumeID
-                                  type: object
-                                projected:
-                                  description: Items for all in one resources secrets,
-                                    configmaps, and downward API
-                                  properties:
-                                    defaultMode:
-                                      description: Mode bits to use on created files
-                                        by default. Must be a value between 0 and
-                                        0777. Directories within the path are not
-                                        affected by this setting. This might be in
-                                        conflict with other options that affect the
-                                        file mode, like fsGroup, and the result can
-                                        be other mode bits set.
-                                      format: int32
-                                      type: integer
-                                    sources:
-                                      description: list of volume projections
-                                      items:
-                                        description: Projection that may be projected
-                                          along with other supported volume types
-                                        properties:
-                                          configMap:
-                                            description: information about the configMap
-                                              data to project
-                                            properties:
-                                              items:
-                                                description: If unspecified, each
-                                                  key-value pair in the Data field
-                                                  of the referenced ConfigMap will
-                                                  be projected into the volume as
-                                                  a file whose name is the key and
-                                                  content is the value. If specified,
-                                                  the listed keys will be projected
-                                                  into the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the ConfigMap, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
-                                                items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
-                                                  properties:
-                                                    key:
-                                                      description: The key to project.
-                                                      type: string
-                                                    mode:
-                                                      description: 'Optional: mode
-                                                        bits to use on this file,
-                                                        must be a value between 0
-                                                        and 0777. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      description: The relative path
-                                                        of the file to map the key
-                                                        to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
-                                                      type: string
-                                                  required:
-                                                  - key
-                                                  - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
-                                                type: string
-                                              optional:
-                                                description: Specify whether the ConfigMap
-                                                  or its keys must be defined
-                                                type: boolean
-                                            type: object
-                                          downwardAPI:
-                                            description: information about the downwardAPI
-                                              data to project
-                                            properties:
-                                              items:
-                                                description: Items is a list of DownwardAPIVolume
-                                                  file
-                                                items:
-                                                  description: DownwardAPIVolumeFile
-                                                    represents information to create
-                                                    the file containing the pod field
-                                                  properties:
-                                                    fieldRef:
-                                                      description: 'Required: Selects
-                                                        a field of the pod: only annotations,
-                                                        labels, name and namespace
-                                                        are supported.'
-                                                      properties:
-                                                        apiVersion:
-                                                          description: Version of
-                                                            the schema the FieldPath
-                                                            is written in terms of,
-                                                            defaults to "v1".
-                                                          type: string
-                                                        fieldPath:
-                                                          description: Path of the
-                                                            field to select in the
-                                                            specified API version.
-                                                          type: string
-                                                      required:
-                                                      - fieldPath
-                                                      type: object
-                                                    mode:
-                                                      description: 'Optional: mode
-                                                        bits to use on this file,
-                                                        must be a value between 0
-                                                        and 0777. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      description: 'Required: Path
-                                                        is  the relative path name
-                                                        of the file to be created.
-                                                        Must not be absolute or contain
-                                                        the ''..'' path. Must be utf-8
-                                                        encoded. The first item of
-                                                        the relative path must not
-                                                        start with ''..'''
-                                                      type: string
-                                                    resourceFieldRef:
-                                                      description: 'Selects a resource
-                                                        of the container: only resources
-                                                        limits and requests (limits.cpu,
-                                                        limits.memory, requests.cpu
-                                                        and requests.memory) are currently
-                                                        supported.'
-                                                      properties:
-                                                        containerName:
-                                                          description: 'Container
-                                                            name: required for volumes,
-                                                            optional for env vars'
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                          description: Specifies the
-                                                            output format of the exposed
-                                                            resources, defaults to
-                                                            "1"
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          description: 'Required:
-                                                            resource to select'
-                                                          type: string
-                                                      required:
-                                                      - resource
-                                                      type: object
-                                                  required:
-                                                  - path
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          secret:
-                                            description: information about the secret
-                                              data to project
-                                            properties:
-                                              items:
-                                                description: If unspecified, each
-                                                  key-value pair in the Data field
-                                                  of the referenced Secret will be
-                                                  projected into the volume as a file
-                                                  whose name is the key and content
-                                                  is the value. If specified, the
-                                                  listed keys will be projected into
-                                                  the specified paths, and unlisted
-                                                  keys will not be present. If a key
-                                                  is specified which is not present
-                                                  in the Secret, the volume setup
-                                                  will error unless it is marked optional.
-                                                  Paths must be relative and may not
-                                                  contain the '..' path or start with
-                                                  '..'.
-                                                items:
-                                                  description: Maps a string key to
-                                                    a path within a volume.
-                                                  properties:
-                                                    key:
-                                                      description: The key to project.
-                                                      type: string
-                                                    mode:
-                                                      description: 'Optional: mode
-                                                        bits to use on this file,
-                                                        must be a value between 0
-                                                        and 0777. If not specified,
-                                                        the volume defaultMode will
-                                                        be used. This might be in
-                                                        conflict with other options
-                                                        that affect the file mode,
-                                                        like fsGroup, and the result
-                                                        can be other mode bits set.'
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      description: The relative path
-                                                        of the file to map the key
-                                                        to. May not be an absolute
-                                                        path. May not contain the
-                                                        path element '..'. May not
-                                                        start with the string '..'.
-                                                      type: string
-                                                  required:
-                                                  - key
-                                                  - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                description: 'Name of the referent.
-                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                  TODO: Add other useful fields. apiVersion,
-                                                  kind, uid?'
-                                                type: string
-                                              optional:
-                                                description: Specify whether the Secret
-                                                  or its key must be defined
-                                                type: boolean
-                                            type: object
-                                          serviceAccountToken:
-                                            description: information about the serviceAccountToken
-                                              data to project
-                                            properties:
-                                              audience:
-                                                description: Audience is the intended
-                                                  audience of the token. A recipient
-                                                  of a token must identify itself
-                                                  with an identifier specified in
-                                                  the audience of the token, and otherwise
-                                                  should reject the token. The audience
-                                                  defaults to the identifier of the
-                                                  apiserver.
-                                                type: string
-                                              expirationSeconds:
-                                                description: ExpirationSeconds is
-                                                  the requested duration of validity
-                                                  of the service account token. As
-                                                  the token approaches expiration,
-                                                  the kubelet volume plugin will proactively
-                                                  rotate the service account token.
-                                                  The kubelet will start trying to
-                                                  rotate the token if the token is
-                                                  older than 80 percent of its time
-                                                  to live or if the token is older
-                                                  than 24 hours.Defaults to 1 hour
-                                                  and must be at least 10 minutes.
-                                                format: int64
-                                                type: integer
-                                              path:
-                                                description: Path is the path relative
-                                                  to the mount point of the file to
-                                                  project the token into.
-                                                type: string
-                                            required:
-                                            - path
-                                            type: object
-                                        type: object
-                                      type: array
-                                  required:
-                                  - sources
-                                  type: object
-                                quobyte:
-                                  description: Quobyte represents a Quobyte mount
-                                    on the host that shares a pod's lifetime
-                                  properties:
-                                    group:
-                                      description: Group to map volume access to Default
-                                        is no group
-                                      type: string
-                                    readOnly:
-                                      description: ReadOnly here will force the Quobyte
-                                        volume to be mounted with read-only permissions.
-                                        Defaults to false.
-                                      type: boolean
-                                    registry:
-                                      description: Registry represents a single or
-                                        multiple Quobyte Registry services specified
-                                        as a string as host:port pair (multiple entries
-                                        are separated with commas) which acts as the
-                                        central registry for volumes
-                                      type: string
-                                    tenant:
-                                      description: Tenant owning the given Quobyte
-                                        volume in the Backend Used with dynamically
-                                        provisioned Quobyte volumes, value is set
-                                        by the plugin
-                                      type: string
-                                    user:
-                                      description: User to map volume access to Defaults
-                                        to serivceaccount user
-                                      type: string
-                                    volume:
-                                      description: Volume is a string that references
-                                        an already created Quobyte volume by name.
-                                      type: string
-                                  required:
-                                  - registry
-                                  - volume
-                                  type: object
-                                rbd:
-                                  description: 'RBD represents a Rados Block Device
-                                    mount on the host that shares a pod''s lifetime.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md'
-                                  properties:
-                                    fsType:
-                                      description: 'Filesystem type of the volume
-                                        that you want to mount. Tip: Ensure that the
-                                        filesystem type is supported by the host operating
-                                        system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                        inferred to be "ext4" if unspecified. More
-                                        info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                        TODO: how do we prevent errors in the filesystem
-                                        from compromising the machine'
-                                      type: string
-                                    image:
-                                      description: 'The rados image name. More info:
-                                        https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      type: string
-                                    keyring:
-                                      description: 'Keyring is the path to key ring
-                                        for RBDUser. Default is /etc/ceph/keyring.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      type: string
-                                    monitors:
-                                      description: 'A collection of Ceph monitors.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      items:
-                                        type: string
-                                      type: array
-                                    pool:
-                                      description: 'The rados pool name. Default is
-                                        rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      type: string
-                                    readOnly:
-                                      description: 'ReadOnly here will force the ReadOnly
-                                        setting in VolumeMounts. Defaults to false.
-                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      type: boolean
-                                    secretRef:
-                                      description: 'SecretRef is name of the authentication
-                                        secret for RBDUser. If provided overrides
-                                        keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    user:
-                                      description: 'The rados user name. Default is
-                                        admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                                      type: string
-                                  required:
-                                  - image
-                                  - monitors
-                                  type: object
-                                scaleIO:
-                                  description: ScaleIO represents a ScaleIO persistent
-                                    volume attached and mounted on Kubernetes nodes.
-                                  properties:
-                                    fsType:
-                                      description: Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Default is "xfs".
-                                      type: string
-                                    gateway:
-                                      description: The host address of the ScaleIO
-                                        API Gateway.
-                                      type: string
-                                    protectionDomain:
-                                      description: The name of the ScaleIO Protection
-                                        Domain for the configured storage.
-                                      type: string
-                                    readOnly:
-                                      description: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
-                                      type: boolean
-                                    secretRef:
-                                      description: SecretRef references to the secret
-                                        for ScaleIO user and other sensitive information.
-                                        If this is not provided, Login operation will
-                                        fail.
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    sslEnabled:
-                                      description: Flag to enable/disable SSL communication
-                                        with Gateway, default false
-                                      type: boolean
-                                    storageMode:
-                                      description: Indicates whether the storage for
-                                        a volume should be ThickProvisioned or ThinProvisioned.
-                                        Default is ThinProvisioned.
-                                      type: string
-                                    storagePool:
-                                      description: The ScaleIO Storage Pool associated
-                                        with the protection domain.
-                                      type: string
-                                    system:
-                                      description: The name of the storage system
-                                        as configured in ScaleIO.
-                                      type: string
-                                    volumeName:
-                                      description: The name of a volume already created
-                                        in the ScaleIO system that is associated with
-                                        this volume source.
-                                      type: string
-                                  required:
-                                  - gateway
-                                  - secretRef
-                                  - system
-                                  type: object
-                                secret:
-                                  description: 'Secret represents a secret that should
-                                    populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                  properties:
-                                    defaultMode:
-                                      description: 'Optional: mode bits to use on
-                                        created files by default. Must be a value
-                                        between 0 and 0777. Defaults to 0644. Directories
-                                        within the path are not affected by this setting.
-                                        This might be in conflict with other options
-                                        that affect the file mode, like fsGroup, and
-                                        the result can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    items:
-                                      description: If unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified
-                                        which is not present in the Secret, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain
-                                        the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within
-                                          a volume.
-                                        properties:
-                                          key:
-                                            description: The key to project.
-                                            type: string
-                                          mode:
-                                            description: 'Optional: mode bits to use
-                                              on this file, must be a value between
-                                              0 and 0777. If not specified, the volume
-                                              defaultMode will be used. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: The relative path of the
-                                              file to map the key to. May not be an
-                                              absolute path. May not contain the path
-                                              element '..'. May not start with the
-                                              string '..'.
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        keys must be defined
-                                      type: boolean
-                                    secretName:
-                                      description: 'Name of the secret in the pod''s
-                                        namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                      type: string
-                                  type: object
-                                storageos:
-                                  description: StorageOS represents a StorageOS volume
-                                    attached and mounted on Kubernetes nodes.
-                                  properties:
-                                    fsType:
-                                      description: Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
-                                      type: string
-                                    readOnly:
-                                      description: Defaults to false (read/write).
-                                        ReadOnly here will force the ReadOnly setting
-                                        in VolumeMounts.
-                                      type: boolean
-                                    secretRef:
-                                      description: SecretRef specifies the secret
-                                        to use for obtaining the StorageOS API credentials.  If
-                                        not specified, default values will be attempted.
-                                      properties:
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                      type: object
-                                    volumeName:
-                                      description: VolumeName is the human-readable
-                                        name of the StorageOS volume.  Volume names
-                                        are only unique within a namespace.
-                                      type: string
-                                    volumeNamespace:
-                                      description: VolumeNamespace specifies the scope
-                                        of the volume within StorageOS.  If no namespace
-                                        is specified then the Pod's namespace will
-                                        be used.  This allows the Kubernetes name
-                                        scoping to be mirrored within StorageOS for
-                                        tighter integration. Set VolumeName to any
-                                        name to override the default behaviour. Set
-                                        to "default" if you are not using namespaces
-                                        within StorageOS. Namespaces that do not pre-exist
-                                        within StorageOS will be created.
-                                      type: string
-                                  type: object
-                                vsphereVolume:
-                                  description: VsphereVolume represents a vSphere
-                                    volume attached and mounted on kubelets host machine
-                                  properties:
-                                    fsType:
-                                      description: Filesystem type to mount. Must
-                                        be a filesystem type supported by the host
-                                        operating system. Ex. "ext4", "xfs", "ntfs".
-                                        Implicitly inferred to be "ext4" if unspecified.
-                                      type: string
-                                    storagePolicyID:
-                                      description: Storage Policy Based Management
-                                        (SPBM) profile ID associated with the StoragePolicyName.
-                                      type: string
-                                    storagePolicyName:
-                                      description: Storage Policy Based Management
-                                        (SPBM) profile name.
-                                      type: string
-                                    volumePath:
-                                      description: Path that identifies vSphere volume
-                                        vmdk
-                                      type: string
-                                  required:
-                                  - volumePath
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            type: array
-                        type: object
+                  managed:
+                    description: Managed defines whether backups are managed by us or the clients.
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector defines which nodes to constrain the pods that run any backup operations to
                     type: object
                   resources:
-                    description: Resources is the resource requirements for the couchbase
-                      container. This field cannot be updated once the cluster is
-                      created.
+                    description: Resources is the resource requirements for the backup container. Will be populated by defaults if not specified.
                     properties:
                       limits:
                         additionalProperties:
@@ -7152,8 +791,7 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                       requests:
                         additionalProperties:
@@ -7162,22 +800,636 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  serverGroups:
-                    description: ServerGroups define the set of availability zones
-                      we want to distribute pods over.  This allows the Kubernetes
-                      cluster administrator to label all nodes, but use a specific
-                      subset for a particular Couchbase cluster.
+                  s3Secret:
+                    description: S3Secret contains the region and credentials for operating backups in S3
+                    type: string
+                  selector:
+                    description: Selector allows CouchbaseBackup and CouchbaseBackupRestore resources to be filtered based on labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: The Service Account to run backup (and restore) pods under. Without this backup pods will not be able to update status
+                    type: string
+                  tolerations:
+                    description: Tolerations specifies all backup pod tolerations.
                     items:
-                      type: string
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
                     type: array
-                  services:
-                    description: The services to run on nodes created with this spec
+                type: object
+              buckets:
+                description: Buckets defines whether the Operator should manage buckets, and how to lookup bucket resources.
+                properties:
+                  managed:
+                    description: Managed defines whether buckets are managed by us or the clients.
+                    type: boolean
+                  selector:
+                    description: Selector is a label selector used to list buckets in the namespace that are managed by the Operator.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                type: object
+              cluster:
+                default: {}
+                description: ClusterSettings define Couchbase cluster-wide settings such as memory allocation, failover characteristics and index settings.
+                properties:
+                  analyticsServiceMemoryQuota:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 1Gi
+                    description: 'AnalyticsServiceMemQuota is the amount of memory that should be allocated to the analytics service. This value is per-pod, and only applicable to pods belonging to server classes running the analytics service.  This field must be a quantity greater than or equal to 1Gi.  This field defaults to 1Gi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  autoCompaction:
+                    default: {}
+                    description: AutoCompaction allows the configuration of auto-compaction, including on what conditions disk space is reclaimed and when it is allowed to run.
+                    properties:
+                      databaseFragmentationThreshold:
+                        default: {}
+                        description: DatabaseFragmentationThreshold defines triggers for when database compaction should start.
+                        properties:
+                          percent:
+                            default: 30
+                            description: Percent is the percentage of disk fragmentation after which to decompaction will be triggered. This field must be in the range 2-100, defaulting to 30.
+                            maximum: 100
+                            minimum: 2
+                            type: integer
+                          size:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Size is the amount of disk framentation, that once exceeded, will trigger decompaction. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      parallelCompaction:
+                        description: ParallelCompaction controls whether database and view compactions can happen in parallel.
+                        type: boolean
+                      timeWindow:
+                        description: TimeWindow allows restriction of when compaction can occur.
+                        properties:
+                          abortCompactionOutsideWindow:
+                            description: AbortCompactionOutsideWindow stops compaction processes when the process moves outside the window.
+                            type: boolean
+                          end:
+                            description: End is a wallclock time, in the form HH:MM, when a compaction should stop.
+                            pattern: ^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$
+                            type: string
+                          start:
+                            description: Start is a wallclock time, in the form HH:MM, when a compaction is permitted to start.
+                            pattern: ^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$
+                            type: string
+                        type: object
+                      tombstonePurgeInterval:
+                        default: 72h
+                        description: 'TombstonePurgeInterval controls how long to wait before purging tombstones. This field must be in the range 1h-1440h, defaulting to 72h. More info:  https://golang.org/pkg/time/#ParseDuration'
+                        type: string
+                      viewFragmentationThreshold:
+                        default: {}
+                        description: ViewFragmentationThreshold defines triggers for when view compaction should start.
+                        properties:
+                          percent:
+                            default: 30
+                            description: Percent is the percentage of disk fragmentation after which to decompaction will be triggered. This field must be in the range 2-100, defaulting to 30.
+                            maximum: 100
+                            minimum: 2
+                            type: integer
+                          size:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: 'Size is the amount of disk framentation, that once exceeded, will trigger decompaction. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  autoFailoverMaxCount:
+                    default: 3
+                    description: AutoFailoverMaxCount is the maximum number of automatic failovers Couchbase server will allow before not allowing any more.  This field must be between 1-3, default 3.
+                    format: int64
+                    maximum: 3
+                    minimum: 1
+                    type: integer
+                  autoFailoverOnDataDiskIssues:
+                    description: AutoFailoverOnDataDiskIssues defines whether Couchbase server should failover a pod if a disk issue was detected.
+                    type: boolean
+                  autoFailoverOnDataDiskIssuesTimePeriod:
+                    default: 120s
+                    description: 'AutoFailoverOnDataDiskIssuesTimePeriod defines how long to wait for transient errors before failing over a faulty disk.  This field must be in the range 5-3600s, defaulting to 120s.  More info:  https://golang.org/pkg/time/#ParseDuration'
+                    type: string
+                  autoFailoverServerGroup:
+                    description: AutoFailoverServerGroup whether to enable failing over a server group.
+                    type: boolean
+                  autoFailoverTimeout:
+                    default: 120s
+                    description: 'AutoFailoverTimeout defines how long Couchbase server will wait between a pod being witnessed as down, until when it will failover the pod.  Couchbase server will only failover pods if it deems it safe to do so, and not result in data loss.  This field must be in the range 5-3600s, defaulting to 120s. More info:  https://golang.org/pkg/time/#ParseDuration'
+                    type: string
+                  clusterName:
+                    description: ClusterName defines the name of the cluster, as displayed in the Couchbase UI. By default, the cluster name is that specified in the CouchbaseCluster resource's metadata.
+                    type: string
+                  data:
+                    description: Data allows the data service to be configured.
+                    properties:
+                      readerThreads:
+                        description: ReaderThreads allows the number of threads used by the data service, per pod, to be altered.  This value must be between 4 and 64 threads, and should only be increased where there are sufficient CPU resources allocated for their use.  If not specified, this defaults to the default value set by Couchbase Server.
+                        maximum: 64
+                        minimum: 4
+                        type: integer
+                      writerThreads:
+                        description: ReaderThreads allows the number of threads used by the data service, per pod, to be altered.  This setting is especially relevant when using "durable writes", increaing this field will have a large impact on performance.  This value must be between 4 and 64 threads, and should only be increased where there are sufficient CPU resources allocated for their use. If not specified, this defaults to the default value set by Couchbase Server.
+                        maximum: 64
+                        minimum: 4
+                        type: integer
+                    type: object
+                  dataServiceMemoryQuota:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 256Mi
+                    description: 'DataServiceMemQuota is the amount of memory that should be allocated to the data service. This value is per-pod, and only applicable to pods belonging to server classes running the data service.  This field must be a quantity greater than or equal to 256Mi.  This field defaults to 256Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  eventingServiceMemoryQuota:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 256Mi
+                    description: 'EventingServiceMemQuota is the amount of memory that should be allocated to the eventing service. This value is per-pod, and only applicable to pods belonging to server classes running the eventing service.  This field must be a quantity greater than or equal to 256Mi.  This field defaults to 256Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  indexServiceMemoryQuota:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 256Mi
+                    description: 'IndexServiceMemQuota is the amount of memory that should be allocated to the index service. This value is per-pod, and only applicable to pods belonging to server classes running the index service.  This field must be a quantity greater than or equal to 256Mi.  This field defaults to 256Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  indexStorageSetting:
+                    default: memory_optimized
+                    description: DEPRECATED - by indexer. The index storage mode to use for secondary indexing.  This field must be one of "memory_optimized" or "plasma", defaulting to "memory_optimized".  This field is immutable and cannot be changed unless there are no server classes running the index service in the cluster.
+                    enum:
+                    - memory_optimized
+                    - plasma
+                    type: string
+                  indexer:
+                    description: Indexer allows the indexer to be configured.
+                    properties:
+                      logLevel:
+                        default: info
+                        description: LogLevel controls the verbosity of indexer logs.  This field must be one of "silent", "fatal", "error", "warn", "info", "verbose", "timing", "debug" or "trace", defaulting to "info".
+                        enum:
+                        - silent
+                        - fatal
+                        - error
+                        - warn
+                        - info
+                        - verbose
+                        - timing
+                        - debug
+                        - trace
+                        type: string
+                      maxRollbackPoints:
+                        default: 2
+                        description: MaxRollbackPoints controls the number of checkpoints that can be rolled back to.  The default is 2, with a minimum of 1.
+                        minimum: 1
+                        type: integer
+                      memorySnapshotInterval:
+                        default: 200ms
+                        description: MemorySnapshotInterval controls when memory indexes should be snapshotted. This defaults to 200ms, and must be greater than or equal to 1ms.
+                        type: string
+                      stableSnapshotInterval:
+                        default: 5s
+                        description: StableSnapshotInterval controls when disk indexes should be snapshotted. This defaults to 5s, and must be greater than or equal to 1ms.
+                        type: string
+                      storageMode:
+                        default: memory_optimized
+                        description: StorageMode controls the underlying storage engine for indexes.  Once set it can only be modified if there are no nodes in the cluster running the index service.  The field must be one of "memory_optimized" or "plasma", defaulting to "memory_optimized".
+                        enum:
+                        - memory_optimized
+                        - plasma
+                        type: string
+                      threads:
+                        description: Threads controls the number of processor threads to use for indexing. A value of 0 means 1 per CPU.  This attribute must be greater than or equal to 0, defaulting to 0.
+                        minimum: 0
+                        type: integer
+                    type: object
+                  query:
+                    description: Query allows the query service to be configured.
+                    properties:
+                      backfillEnabled:
+                        default: true
+                        description: BackfillEnabled allows the query service to backfill.
+                        type: boolean
+                      temporarySpace:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 5Gi
+                        description: TemporarySpace allows the temporary storage used by the query service backfill, per-pod, to be modified.  This field requires `backfillEnabled` to be set to true in order to have any effect.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      temporarySpaceUnlimited:
+                        description: TemporarySpaceUnlimited allows the temporary storage used by the query service backfill, per-pod, to be unconstrainend.  This field requires `backfillEnabled` to be set to true in order to have any effect. This field overrides `temporarySpace`.
+                        type: boolean
+                    type: object
+                  queryServiceMemoryQuota:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: QueryServiceMemQuota is a dummy field.  By default, Couchbase server provides no memory resource constrints for the query service, so this has no effect on Couchbase server.  It is, however, used when the spec.autoResourceAllocation feature is enabled, and is used to define the amount of memory reserved by the query service for use with Kubernetes resource scheduling.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                  searchServiceMemoryQuota:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 256Mi
+                    description: 'SearchServiceMemQuota is the amount of memory that should be allocated to the search service. This value is per-pod, and only applicable to pods belonging to server classes running the search service.  This field must be a quantity greater than or equal to 256Mi.  This field defaults to 256Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    type: string
+                    x-kubernetes-int-or-string: true
+                type: object
+              enableOnlineVolumeExpansion:
+                description: "EnableOnlineVolumeExpansion enables online expansion of Persistent Volumes. You can only expand a PVC if its storage class's \"allowVolumeExpansion\" field is set to true. Additionally, Kubernetes feature \"ExpandInUsePersistentVolumes\" must be enabled in order to expand the volumes which are actively bound to Pods. Volumes can only be expanded and not reduced to a smaller size. See: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#resizing-an-in-use-persistentvolumeclaim \n If \"EnableOnlineVolumeExpansion\" is enabled for use within an evironment that does not actually support online volume and file system expansion then the cluster will fallback to rolling upgrade procedure to create a new set of Pods for use with resized Volumes. More info:  https://kubernetes.io/docs/concepts/storage/persistent-volumes/#expanding-persistent-volumes-claims"
+                type: boolean
+              enablePreviewScaling:
+                description: EnablePreviewScaling enables autoscaling for stateful services and buckets. DEPRECATED - This option only exists for backwards compatibility and no longer restricts autoscaling to ephemeral services. To be removed in future releases.
+                type: boolean
+              hibernate:
+                description: Hibernate is whether to hibernate the cluster.
+                type: boolean
+              hibernationStrategy:
+                description: HibernationStrategy defines how to hibernate the cluster.  When Immediate the Operator will immediately delete all pods and take no further action until the hibernate field is set to false.
+                enum:
+                - Immediate
+                type: string
+              image:
+                description: Image is the container image name that will be used to launch Couchbase server instances.  Updating this field will cause an automatic upgrade of the cluster.
+                pattern: ^(.*?(:\d+)?/)?.*?/.*?(:.*?\d+\.\d+\.\d+.*|@sha256:[0-9a-f]{64})$
+                type: string
+              logging:
+                description: Logging defines Operator logging options.
+                properties:
+                  audit:
+                    description: Used to manage the audit configuration directly
+                    properties:
+                      disabledEvents:
+                        description: 'The list of event ids to disable for auditing purposes. This is passed to the REST API with no verification by the operator. Refer to the documentation for details: https://docs.couchbase.com/server/current/audit-event-reference/audit-event-reference.html'
+                        items:
+                          type: integer
+                        type: array
+                      disabledUsers:
+                        description: 'The list of users to ignore for auditing purposes. This is passed to the REST API with minimal validation it meets an acceptable regex pattern. Refer to the documentation for full details on how to configure this: https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html#ignoring-events-by-user'
+                        items:
+                          description: 'The AuditDisabledUser is actually a compound string intended to feed a two-element struct. Its value may be: 1. A local user, specified in the form localusername/local. 2. An external user, specified in the form externalusername/external. 3. An internal user, specified in the form @internalusername/local. We add a quick validation check to make sure these match and prevent being rejected by the API later. This is just a sanity check, the REST API may still reject the user for other reasons.'
+                          pattern: ^.+/(local|external)$
+                          type: string
+                        type: array
+                      enabled:
+                        description: Enabled is a boolean that enables the audit capabilities.
+                        type: boolean
+                      garbageCollection:
+                        description: 'Handle all optional garbage collection (GC) configuration for the audit functionality. This is not part of the audit REST API, it is intended to handle GC automatically for the audit logs. By default the Couchbase Server rotates the audit logs but does not clean up the rotated logs. This is left as an operation for the cluster administrator to manage, the operator allows for us to automate this: https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html'
+                        properties:
+                          sidecar:
+                            description: Provide the sidecar configuration required (if so desired) to automatically clean up audit logs.
+                            properties:
+                              age:
+                                default: 1h
+                                description: The minimum age of rotated log files to remove, defaults to one hour.
+                                type: string
+                              enabled:
+                                description: Enable this sidecar by setting to true, defaults to being disabled.
+                                type: boolean
+                              image:
+                                default: busybox:1.32.1
+                                description: Image is the image to be used to run the audit sidecar helper. No validation is carried out as this can be any arbitrary repo and tag.
+                                type: string
+                              interval:
+                                default: 20m
+                                description: The interval at which to check for rotated log files to remove, defaults to 20 minutes.
+                                type: string
+                              resources:
+                                description: Resources is the resource requirements for the cleanup container. Will be populated by Kubernetes defaults if not specified.
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      rotation:
+                        description: 'The interval to optionally rotate the audit log. This is passed to the REST API, see here for details: https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html'
+                        properties:
+                          interval:
+                            default: 15m
+                            description: The interval at which to rotate log files, defaults to 15 minutes.
+                            type: string
+                          size:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            default: 20Mi
+                            description: Size allows the specification of a rotation size for the log, defaults to 20Mi.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                    type: object
+                  logRetentionCount:
+                    description: LogRetentionCount gives the number of persistent log PVCs to keep.
+                    minimum: 0
+                    type: integer
+                  logRetentionTime:
+                    description: LogRetentionTime gives the time to keep persistent log PVCs alive for.
+                    pattern: ^\d+(ns|us|ms|s|m|h)$
+                    type: string
+                  server:
+                    description: Specification of all logging configuration required to manage the sidecar containers in each pod.
+                    properties:
+                      configurationName:
+                        default: fluent-bit-config
+                        description: ConfigurationName is the name of the Secret to use holding the logging configuration in the namespace. A Secret is used to ensure we can safely store credentials but this can be populated from plaintext if acceptable too. If it does not exist then one will be created with defaults in the namespace so it can be easily updated whilst running.
+                        type: string
+                      enabled:
+                        description: Enabled is a boolean that enables the logging sidecar container.
+                        type: boolean
+                      manageConfiguration:
+                        default: true
+                        description: A boolean which indicates whether the operator should manage the configuration or not. If omitted then this defaults to true which means the operator will attempt to reconcile it to default values. To use a custom configuration make sure to set this to false.
+                        type: boolean
+                      sidecar:
+                        default: {}
+                        description: Any specific logging sidecar container configuration.
+                        properties:
+                          configurationMountPath:
+                            default: /fluent-bit/config/
+                            description: ConfigurationMountPath is the location to mount the ConfigurationName Secret into the image. If another log shipping image is used that needs a different mount then modify this.
+                            type: string
+                          image:
+                            default: couchbase/fluent-bit:1.0.0
+                            description: Image is the image to be used to deal with logging as a sidecar. No validation is carried out as this can be any arbitrary repo and tag. It will default to the latest supported version of Fluent Bit.
+                            type: string
+                          resources:
+                            description: Resources is the resource requirements for the sidecar container. Will be populated by Kubernetes defaults if not specified.
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              monitoring:
+                description: Monitoring defines any Operator managed integration into 3rd party monitoring infrastructure.
+                properties:
+                  prometheus:
+                    description: Prometheus provides integration with Prometheus monitoring.
+                    properties:
+                      authorizationSecret:
+                        description: AuthorizationSecret is the name of a Kubernetes secret that contains a bearer token to authorize GET requests to the metrics endpoint
+                        type: string
+                      enabled:
+                        description: Enabled is a boolean that enables/disables the metrics sidecar container.
+                        type: boolean
+                      image:
+                        description: Image is the metrics image to be used to collect metrics. No validation is carried out as this can be any arbitrary repo and tag.
+                        type: string
+                      resources:
+                        description: Resources is the resource requirements for the metrics container. Will be populated by Kubernetes defaults if not specified.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              networking:
+                description: Networking defines Couchbase cluster networking options such as network topology, TLS and DDNS settings.
+                properties:
+                  addressFamily:
+                    description: DEVELOPER PREVIEW - this feature is not for production use. AddressFamily allows the manual selection of the address family to use. Couchbase server will default to "IPv4" regardless of underlying network configuration, so this must be manually set to enable use on an "IPv6" only network.  This field is immutable and cannot be changed once set.
+                    enum:
+                    - IPv4
+                    - IPv6
+                    type: string
+                  adminConsoleServiceTemplate:
+                    description: 'AdminConsoleServiceTemplate provides a template used by the Operator to create and manage the admin console service.  This allows services to be annotated, the service type defined and any other options that Kubernetes provides.  When using a LoadBalancer service type, TLS and dynamic DNS must also be enabled. The Operator reserves the right to modify or replace any field.  More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#service-v1-core'
+                    properties:
+                      metadata:
+                        description: Standard objects metadata.  This is a curated version for use with Couchbase resource templates.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      spec:
+                        description: ServiceSpec describes the attributes that a user creates on a service.
+                        properties:
+                          clusterIP:
+                            description: 'clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are "None", empty string (""), or a valid IP address. "None" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be ExternalName.
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck nodePort for the service. If not specified, HealthCheckNodePort is created by the service api backend with the allocated nodePort. Will use user-specified nodePort value if specified by the client. Only effects when Type is set to LoadBalancer and ExternalTrafficPolicy is set to Local.
+                            format: int32
+                            type: integer
+                          ipFamily:
+                            description: ipFamily specifies whether this Service has a preference for a particular IP family (e.g. IPv4 vs. IPv6) when the IPv6DualStack feature gate is enabled. In a dual-stack cluster, you can specify ipFamily when creating a ClusterIP Service to determine whether the controller will allocate an IPv4 or IPv6 IP for it, and you can specify ipFamily when creating a headless Service to determine whether it will have IPv4 or IPv6 Endpoints. In either case, if you do not specify an ipFamily explicitly, it will default to the cluster's primary IP family. This field is part of an alpha feature, and you should not make any assumptions about its semantics other than those described above. In particular, you should not assume that it can (or cannot) be changed after creation time; that it can only have the values "IPv4" and "IPv6"; or that its current value on a given Service correctly reflects the current state of that Service. (For ClusterIP Services, look at clusterIP to see if the Service is IPv4 or IPv6. For headless Services, look at the endpoints, which may be dual-stack in the future. For ExternalName Services, ipFamily has no meaning, but it may be set to an irrelevant value anyway.)
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                            items:
+                              type: string
+                            type: array
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                            type: object
+                          sessionAffinity:
+                            description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          topologyKeys:
+                            description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied.
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ExternalName" maps to the specified externalName. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a stable IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                            type: string
+                        type: object
+                    type: object
+                  adminConsoleServiceType:
+                    default: NodePort
+                    description: DEPRECATED - by adminConsoleServiceTemplate. AdminConsoleServiceType defines whether to create a node port or load balancer service. When using a LoadBalancer service type, TLS and dynamic DNS must also be enabled. This field must be one of "NodePort" or "LoadBalancer", defaulting to "NodePort".
+                    enum:
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                  adminConsoleServices:
+                    description: DEPRECATED - not required by Couchbase Server 6.5.0 onward. AdminConsoleServices is a selector to choose specific services to expose via the admin console. This field may contain any of "data", "index", "query", "search", "eventing" and "analytics".  Each service may only be included once.
                     items:
                       description: Supported services
                       enum:
@@ -7190,141 +1442,341 @@ spec:
                       - analytics
                       type: string
                     type: array
-                  size:
-                    description: Size is the expected size of the couchbase cluster.
-                      The couchbase-operator will eventually make the size of the
-                      running cluster equal to the expected size. The vaild range
-                      of the size is from 1 to 50.
-                    minimum: 1
-                    type: integer
-                  volumeMounts:
-                    description: Volume mounts represent persistent volume claims
-                      to attach to pod. If defined new pods will use persistent volumes.
+                    x-kubernetes-list-type: set
+                  disableUIOverHTTP:
+                    description: DisableUIOverHTTP is used to explicitly enable and disable UI access over the HTTP protocol.  If not specified, this field defaults to false.
+                    type: boolean
+                  disableUIOverHTTPS:
+                    description: DisableUIOverHTTPS is used to explicitly enable and disable UI access over the HTTPS protocol.  If not specified, this field defaults to false.
+                    type: boolean
+                  dns:
+                    description: DNS defines information required for Dynamic DNS support.
                     properties:
-                      analytics:
-                        description: Name of claims to use for analytics paths
-                        items:
-                          type: string
-                        type: array
-                      data:
-                        description: Name of claim to use for data path
-                        type: string
-                      default:
-                        description: Name of claim to use for couchbases default install
-                          path
-                        type: string
-                      index:
-                        description: Name of claim to use for index path
-                        type: string
-                      logs:
-                        description: Name of claim to use for logs path
+                      domain:
+                        description: Domain is the domain to create pods in.  When populated the Operator will annotate the admin console and per-pod services with the key "external-dns.alpha.kubernetes.io/hostname".  These annotations can be used directly by a Kubernetes External-DNS controller to replicate load balancer service IP addresses into a public DNS server.
                         type: string
                     type: object
-                required:
-                - name
-                - services
-                - size
-                type: object
-              minItems: 1
-              type: array
-            softwareUpdateNotifications:
-              description: Enables software update notifications in the UI
-              type: boolean
-            upgradeStrategy:
-              description: This controls how aggressive we are when performing a cluster
-                upgrade.
-              enum:
-              - RollingUpgrade
-              - ImmediateUpgrade
-              type: string
-            volumeClaimTemplates:
-              description: VolumeClaimTemplates define the desired characteristics
-                of a volume that can be requested/claimed by a pod. When specified,
-                each claim should map to the name of a volumeMount defined in a PodPolicy
-              items:
-                description: PersistentVolumeClaim is a user's request for and claim
-                  to a persistent volume
-                properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                    type: object
-                  spec:
-                    description: 'Spec defines the desired characteristics of a volume
-                      requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  exposeAdminConsole:
+                    description: ExposeAdminConsole creates a service referencing the admin console. The service is configured by the adminConsoleServiceTemplate field.
+                    type: boolean
+                  exposedFeatureServiceTemplate:
+                    description: 'ExposedFeatureServiceTemplate provides a template used by the Operator to create and manage per-pod services.  This allows services to be annotated, the service type defined and any other options that Kubernetes provides.  When using a LoadBalancer service type, TLS and dynamic DNS must also be enabled. The Operator reserves the right to modify or replace any field.  More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#service-v1-core'
                     properties:
-                      accessModes:
-                        description: 'AccessModes contains the desired access modes
-                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                        items:
-                          type: string
-                        type: array
-                      resources:
-                        description: 'Resources represents the minimum resources the
-                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                      metadata:
+                        description: Standard objects metadata.  This is a curated version for use with Couchbase resource templates.
                         properties:
-                          limits:
+                          annotations:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: string
+                            description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                             type: object
-                          requests:
+                          labels:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: string
+                            description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
                             type: object
                         type: object
+                      spec:
+                        description: ServiceSpec describes the attributes that a user creates on a service.
+                        properties:
+                          clusterIP:
+                            description: 'clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are "None", empty string (""), or a valid IP address. "None" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          externalIPs:
+                            description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            description: externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires Type to be ExternalName.
+                            type: string
+                          externalTrafficPolicy:
+                            description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                            type: string
+                          healthCheckNodePort:
+                            description: healthCheckNodePort specifies the healthcheck nodePort for the service. If not specified, HealthCheckNodePort is created by the service api backend with the allocated nodePort. Will use user-specified nodePort value if specified by the client. Only effects when Type is set to LoadBalancer and ExternalTrafficPolicy is set to Local.
+                            format: int32
+                            type: integer
+                          ipFamily:
+                            description: ipFamily specifies whether this Service has a preference for a particular IP family (e.g. IPv4 vs. IPv6) when the IPv6DualStack feature gate is enabled. In a dual-stack cluster, you can specify ipFamily when creating a ClusterIP Service to determine whether the controller will allocate an IPv4 or IPv6 IP for it, and you can specify ipFamily when creating a headless Service to determine whether it will have IPv4 or IPv6 Endpoints. In either case, if you do not specify an ipFamily explicitly, it will default to the cluster's primary IP family. This field is part of an alpha feature, and you should not make any assumptions about its semantics other than those described above. In particular, you should not assume that it can (or cannot) be changed after creation time; that it can only have the values "IPv4" and "IPv6"; or that its current value on a given Service correctly reflects the current state of that Service. (For ClusterIP Services, look at clusterIP to see if the Service is IPv4 or IPv6. For headless Services, look at the endpoints, which may be dual-stack in the future. For ExternalName Services, ipFamily has no meaning, but it may be set to an irrelevant value anyway.)
+                            type: string
+                          loadBalancerIP:
+                            description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                            type: string
+                          loadBalancerSourceRanges:
+                            description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                            items:
+                              type: string
+                            type: array
+                          publishNotReadyAddresses:
+                            description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                            type: object
+                          sessionAffinity:
+                            description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                            type: string
+                          sessionAffinityConfig:
+                            description: sessionAffinityConfig contains the configurations of session affinity.
+                            properties:
+                              clientIP:
+                                description: clientIP contains the configurations of Client IP based session affinity.
+                                properties:
+                                  timeoutSeconds:
+                                    description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          topologyKeys:
+                            description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied.
+                            items:
+                              type: string
+                            type: array
+                          type:
+                            description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ExternalName" maps to the specified externalName. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a stable IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                            type: string
+                        type: object
+                    type: object
+                  exposedFeatureServiceType:
+                    default: NodePort
+                    description: DEPRECATED - by exposedFeatureServiceTemplate. ExposedFeatureServiceType defines whether to create a node port or load balancer service. When using a LoadBalancer service type, TLS and dynamic DNS must also be enabled. This field must be one of "NodePort" or "LoadBalancer", defaulting to "NodePort".
+                    enum:
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                  exposedFeatureTrafficPolicy:
+                    description: DEPRECATED  - by exposedFeatureServiceTemplate. ExposedFeatureTrafficPolicy defines how packets should be routed from a load balancer service to a Couchbase pod.  When local, traffic is routed directly to the pod.  When cluster, traffic is routed to any node, then forwarded on.  While cluster routing may be slower, there are some situations where it is required for connectivity.  This field must be either "Cluster" or "Local", defaulting to "Local",
+                    enum:
+                    - Cluster
+                    - Local
+                    type: string
+                  exposedFeatures:
+                    description: ExposedFeatures is a list of Couchbase features to expose when using a networking model that exposes the Couchbase cluster externally to Kubernetes.  This field also triggers the creation of per-pod services used by clients to connect to the Couchbase cluster.  When admin, only the administrator port is exposed, allowing remote administration.  When xdcr, only the services required for remote replication are exposed. The xdcr feature is only required when the cluster is the destrination of an XDCR replication.  When client, all services are exposed as required for client SDK operation. This field may contain any of "admin", "xdcr" and "client".  Each feature may only be included once.
+                    items:
+                      enum:
+                      - admin
+                      - xdcr
+                      - client
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  loadBalancerSourceRanges:
+                    description: DEPRECATED - by adminConsoleServiceTemplate and exposedFeatureServiceTemplate. LoadBalancerSourceRanges applies only when an exposed service is of type LoadBalancer and limits the source IP ranges that are allowed to use the service.  Items must use IPv4 class-less interdomain routing (CIDR) notation e.g. 10.0.0.0/16.
+                    items:
+                      pattern: ^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/\d{1,2}$
+                      type: string
+                    type: array
+                  networkPlatform:
+                    description: NetworkPlatform is used to enable support for various networking technologies.  This field must be one of "Istio".
+                    enum:
+                    - Istio
+                    type: string
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: DEPRECATED - by adminConsoleServiceTemplate and exposedFeatureServiceTemplate. ServiceAnnotations allows services to be annotated with custom labels. Operator annotations are merged on top of these so have precedence as they are required for correct operation.
+                    type: object
+                  tls:
+                    description: TLS defines the TLS configuration for the cluster including server and client certificate configuration, and TLS security policies.
+                    properties:
+                      cipherSuites:
+                        description: CipherSuites specifies a list of cipher suites for Couchbase server to select from when negotiating TLS handshakes with a client.  Suites are not validated by the Operator.  Run "openssl ciphers -v" in a Couchbase server pod to interrogate supported values.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: set
+                      clientCertificatePaths:
+                        description: ClientCertificatePaths defines where to look in client certificates in order to extract the user name.
+                        items:
+                          description: ClientCertificatePath defines how to extract a username from a client ceritficate.
+                          properties:
+                            delimiter:
+                              description: Delimiter if specified allows a suffix to be stripped from the username, once extracted from the certificate path.
+                              type: string
+                            path:
+                              description: Path defines where in the X.509 specification to extract the username from. This field must be either "subject.cn", "san.uri", "san.dnsname" or  "san.email".
+                              pattern: ^subject\.cn|san\.uri|san\.dnsname|san\.email$
+                              type: string
+                            prefix:
+                              description: Prefix allows a prefix to be stripped from the username, once extracted from the certificate path.
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      clientCertificatePolicy:
+                        description: ClientCertificatePolicy defines the client authentication policy to use. If set, the Operator expects TLS configuration to contain a valid certificate/key pair for the Administrator account.
+                        enum:
+                        - enable
+                        - mandatory
+                        type: string
+                      nodeToNodeEncryption:
+                        description: NodeToNodeEncryption specifies whether to encrypt data between Couchbase nodes within the same cluster.  This may come at the expense of performance.  When control plane only encryption is used, only cluster management traffic is encrypted between nodes.  When all, all traffic is encrypted, including database documents. This field must be either "ControlPlaneOnly" or "All".
+                        enum:
+                        - ControlPlaneOnly
+                        - All
+                        type: string
+                      secretSource:
+                        description: SecretSource enables the user to specify a secret conforming to the Kubernetes TLS secret specification.
+                        properties:
+                          clientSecretName:
+                            description: ClientSecretName specifies the secret name, in the same namespace as the cluster, the contains client TLS data.  The secret is expected to contain "tls.crt" and "tls.key" as per the Kubernetes.io/tls secret type.
+                            type: string
+                          serverSecretName:
+                            description: ServerSecretName specfies the secret name, in the same namespace as the cluster, that contains server TLS data.  The secret is expected to contain "tls.crt" and "tls.key" as per the kubernetes.io/tls secret type.  It also additionally must contain "ca.crt".
+                            type: string
+                        required:
+                        - serverSecretName
+                        type: object
+                      static:
+                        description: Static enables user to generate static x509 certificates and keys, put them into Kubernetes secrets, and specify them here.  Static secrets are very Couchbase specific.
+                        properties:
+                          operatorSecret:
+                            description: OperatorSecret is a secret name containing TLS certs used by operator to talk securely to this cluster.  The secret must contain a CA certificate (data key ca.crt).  If client authentication is enabled, then the secret must also contain a client certificate chain (data key "couchbase-operator.crt") and private key (data key "couchbase-operator.key").
+                            type: string
+                          serverSecret:
+                            description: ServerSecret is a secret name containing TLS certs used by each Couchbase member pod for the communication between Couchbase server and its clients.  The secret must contain a certificate chain (data key "couchbase-operator.crt") and a private key (data key "couchbase-operator.key").  The private key must be in the PKCS#1 RSA format.  The certificate chain must have a required set of X.509v3 subject alternative names for all cluster addressing modes.  See the Operator TLS documentation for more information.
+                            type: string
+                        type: object
+                      tlsMinimumVersion:
+                        default: TLS1.2
+                        description: TLSMinimumVersion specifies the minimum TLS version the Couchbase server can negotiate with a client.  Must be one of TLS1.0, TLS1.1 or TLS1.2, defaulting to TLS1.2.
+                        enum:
+                        - TLS1.0
+                        - TLS1.1
+                        - TLS1.2
+                        type: string
+                    type: object
+                type: object
+              paused:
+                description: Paused is to pause the control of the operator for the Couchbase cluster. This does not pause the cluster itself, instead stopping the operator from taking any action.
+                type: boolean
+              platform:
+                description: Platform gives a hint as to what platform we are running on and how to configure services.  This field must be one of "aws", "gke" or "azure".
+                enum:
+                - aws
+                - gce
+                - azure
+                type: string
+              recoveryPolicy:
+                description: RecoveryPolicy controls how aggressive the Operator is when recovering cluster topology.  When PrioritizeDataIntegrity, the Operator will delegate failover exclusively to Couchbase server, relying on it to only allow recovery when safe to do so.  When PrioritizeUptime, the Operator will wait for a period after the expected auto-failover of the cluster, before forcefully failing-over the pods. This may cause data loss, and is only expected to be used on clusters with ephemeral data, where the loss of the pod means that the data is known to be unrecoverable. This field must be either "PrioritizeDataIntegrity" or "PrioritizeUptime", defaulting to "PrioritizeDataIntegrity".
+                enum:
+                - PrioritizeDataIntegrity
+                - PrioritizeUptime
+                type: string
+              rollingUpgrade:
+                description: When `spec.upgradeStrategy` is set to `RollingUpgrade` it will, by default, upgrade one pod at a time.  If this field is specified then that number can be increased.
+                properties:
+                  maxUpgradable:
+                    description: MaxUpgradable allows the number of pods affected by an upgrade at any one time to be increased.  By default a rolling upgrade will upgrade one pod at a time.  This field allows that limit to be removed. This field must be greater than zero. The smallest of `maxUpgradable` and `maxUpgradablePercent` takes precedence if both are defined.
+                    minimum: 1
+                    type: integer
+                  maxUpgradablePercent:
+                    description: MaxUpgradablePercent allows the number of pods affected by an upgrade at any one time to be increased.  By default a rolling upgrade will upgrade one pod at a time.  This field allows that limit to be removed. This field must be an integer percentage, e.g. "10%", in the range 1% to 100%. Percentages are relative to the total cluster size, and rounded down to the nearest whole number, with a minimum of 1.  For example, a 10 pod cluster, and 25% allowed to upgrade, would yield 2.5 pods per iteration, rounded down to 2. The smallest of `maxUpgradable` and `maxUpgradablePercent` takes precedence if both are defined.
+                    pattern: ^(100|[1-9][0-9]|[1-9])%$
+                    type: string
+                type: object
+              security:
+                description: Security defines Couchbase cluster security options such as the administrator account username and password, and user RBAC settings.
+                properties:
+                  adminSecret:
+                    description: AdminSecret is the name of a Kubernetes secret to use for administrator authentication. The admin secret must contain the keys "username" and "password".  The password data must be at least 6 characters in length, and not contain the any of the characters `()<>,;:\"/[]?={}`.
+                    type: string
+                  ldap:
+                    description: LDAP Settings
+                    properties:
+                      authenticationEnabled:
+                        default: true
+                        description: Enables using LDAP to authenticate users.
+                        type: boolean
+                      authorizationEnabled:
+                        description: Enables use of LDAP groups for authorization.
+                        type: boolean
+                      bindDN:
+                        description: DN to use for searching users and groups synchronization.
+                        type: string
+                      bindSecret:
+                        description: BindSecret is the name of a Kubernetes secret to use containing password for LDAP user binding
+                        type: string
+                      cacert:
+                        description: Certificate in PEM format to be used in LDAP server certificate validation
+                        type: string
+                      cacheValueLifetime:
+                        description: Lifetime of values in cache in milliseconds. Default 300000 ms.
+                        format: int64
+                        type: integer
+                      encryption:
+                        description: Encryption method to communicate with LDAP servers. Can be StartTLSExtension, TLS, or false.
+                        enum:
+                        - None
+                        - StartTLSExtension
+                        - TLS
+                        type: string
+                      groupsQuery:
+                        description: LDAP query, to get the users' groups by username in RFC4516 format.
+                        type: string
+                      hosts:
+                        description: List of LDAP hosts.
+                        items:
+                          type: string
+                        type: array
+                      nestedGroupsEnabled:
+                        description: If enabled Couchbase server will try to recursively search for groups for every discovered ldap group. groups_query will be user for the search.
+                        type: boolean
+                      nestedGroupsMaxDepth:
+                        description: 'Maximum number of recursive groups requests the server is allowed to perform. Requires NestedGroupsEnabled.  Values between 1 and 100: the default is 10.'
+                        format: int64
+                        type: integer
+                      port:
+                        description: LDAP port
+                        type: integer
+                      serverCertValidation:
+                        description: Whether server certificate validation be enabled
+                        type: boolean
+                      tlsSecret:
+                        description: TLSSecret is the name of a Kubernetes secret to use for LDAP ca cert.
+                        type: string
+                      userDNMapping:
+                        description: User to distinguished name (DN) mapping. If none is specified, the username is used as the user’s distinguished name.
+                        properties:
+                          query:
+                            description: Query is the LDAP query to run to map from Couchbase user to LDAP distinguished name.
+                            type: string
+                          template:
+                            description: This field specifies list of templates to use for providing username to DN mapping. The template may contain a placeholder specified as `%u` to represent the Couchbase user who is attempting to gain access.
+                            type: string
+                        type: object
+                    required:
+                    - bindSecret
+                    - hosts
+                    - port
+                    type: object
+                  rbac:
+                    description: Couchbase RBAC Users
+                    properties:
+                      managed:
+                        description: Managed defines whether RBAC is managed by us or the clients.
+                        type: boolean
                       selector:
-                        description: A label query over volumes to consider for binding.
+                        description: Selector is a label selector used to list RBAC resources in the namespace that are managed by the Operator.
                         properties:
                           matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                               properties:
                                 key:
-                                  description: key is the label key that the selector
-                                    applies to.
+                                  description: key is the label key that the selector applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -7336,446 +1788,3020 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
-                      storageClassName:
-                        description: 'Name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                        type: string
-                      volumeMode:
-                        description: volumeMode defines what type of volume is required
-                          by the claim. Value of Filesystem is implied when not included
-                          in claim spec. This is a beta feature.
-                        type: string
-                      volumeName:
-                        description: VolumeName is the binding reference to the PersistentVolume
-                          backing this claim.
-                        type: string
                     type: object
-                  status:
-                    description: 'Status represents the current information/status
-                      of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                    properties:
-                      accessModes:
-                        description: 'AccessModes contains the actual access modes
-                          the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                        items:
-                          type: string
-                        type: array
-                      capacity:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: Represents the actual resources of the underlying
-                          volume.
-                        type: object
-                      conditions:
-                        description: Current Condition of persistent volume claim.
-                          If underlying persistent volume is being resized then the
-                          Condition will be set to 'ResizeStarted'.
-                        items:
-                          description: PersistentVolumeClaimCondition contails details
-                            about state of pvc
-                          properties:
-                            lastProbeTime:
-                              description: Last time we probed the condition.
-                              format: date-time
-                              type: string
-                            lastTransitionTime:
-                              description: Last time the condition transitioned from
-                                one status to another.
-                              format: date-time
-                              type: string
-                            message:
-                              description: Human-readable message indicating details
-                                about last transition.
-                              type: string
-                            reason:
-                              description: Unique, this should be a short, machine
-                                understandable string that gives the reason for condition's
-                                last transition. If it reports "ResizeStarted" that
-                                means the underlying persistent volume is being resized.
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              description: PersistentVolumeClaimConditionType is a
-                                valid value of PersistentVolumeClaimCondition.Type
-                              type: string
-                          required:
-                          - status
-                          - type
-                          type: object
-                        type: array
-                      phase:
-                        description: Phase represents the current phase of PersistentVolumeClaim.
-                        type: string
-                    type: object
-                type: object
-              type: array
-            xdcr:
-              description: XDCR specific settings.
-              properties:
-                managed:
-                  description: Managed defines whether XDCR is managed by the operator
-                    or not.
-                  type: boolean
-                remoteClusters:
-                  description: RemoteClusters is a set of named remote clusters to
-                    establish replications to.
-                  items:
-                    description: RemoteCluster is a reference to a remote cluster
-                      for XDCR.
-                    properties:
-                      authenticationSecret:
-                        description: AuthenticationSecret is a secret used to authenticate
-                          when establishing a remote connection.  It is only required
-                          when not using mTLS
-                        type: string
-                      hostname:
-                        description: Hostname is the connection string to use to connect
-                          the remote cluster.
-                        pattern: ^((couchbase|couchbases|http|https)://)?[0-9a-zA-Z\-\.]+(:\d+)?(\?network=[^&]+)?$
-                        type: string
-                      name:
-                        description: Name of the remote cluster.  Referenced by Replications.
-                        type: string
-                      replications:
-                        description: Replications are replication streams from this
-                          cluster to the remote one.
-                        properties:
-                          selector:
-                            description: Selector allows CouchbaseReplication resources
-                              to be filtered based on labels.
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      items:
-                                        type: string
-                                      type: array
-                                  required:
-                                  - key
-                                  - operator
-                                  type: object
-                                type: array
-                              matchLabels:
-                                additionalProperties:
-                                  type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                            type: object
-                        type: object
-                      tls:
-                        description: TLS if specified references a resource containing
-                          the necessary certificate data.
-                        properties:
-                          secret:
-                            description: Secret references a secret containing the
-                              CA certificate, and optionally a client certificate
-                              and key.
-                            type: string
-                        required:
-                        - secret
-                        type: object
-                      uuid:
-                        description: UUID of the remote cluster.
-                        pattern: ^[0-9a-f]{32}$
-                        type: string
-                    type: object
-                  type: array
-              type: object
-          required:
-          - image
-          - security
-          - servers
-          type: object
-        status:
-          properties:
-            allocations:
-              description: Allocations shows memory allocations within server classes.
-              items:
-                description: ServerClassStatus summarizes memory allocations to make
-                  configuration easier.
-                properties:
-                  allocatedMemory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: AllocatedMemory defines the total memory allocated
-                      for constrained Couchbase services.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  allocatedMemoryPercent:
-                    description: AllocatedMemoryPercent is set when memory resources
-                      are requested and define how much of the requested memory is
-                      allocated to constrained Couchbase services.
-                    type: integer
-                  analyticsServiceAllocation:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: AnalyticsServiceAllocation is set when the analytics
-                      service is enabled for this class and defines how much memory
-                      this service consumes per pod.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  dataServiceAllocation:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: DataServiceAllocation is set when the data service
-                      is enabled for this class and defines how much memory this service
-                      consumes per pod.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  eventingServiceAllocation:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: EventingServiceAllocation is set when the eventing
-                      service is enabled for this class and defines how much memory
-                      this service consumes per pod.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  indexServiceAllocation:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: IndexServiceAllocation is set when the index service
-                      is enabled for this class and defines how much memory this service
-                      consumes per pod.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  name:
-                    description: Name is the name of the server class defined in spec.servers
-                    type: string
-                  requestedMemory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: RequestedMemory, if set, defines the Kubernetes resource
-                      request for the server class.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  searchServiceAllocation:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: SearchServiceAllocation is set when the search service
-                      is enabled for this class and defines how much memory this service
-                      consumes per pod.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  unusedMemory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: UnusedMemory is set when memory resources are requested
-                      and is the difference between the requestedMemory and allocatedMemory.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  unusedMemoryPercent:
-                    description: UnusedMemoryPercent is set when memory resources
-                      are requested and defines how much requested memory is not allocated.  Couchbase
-                      server expects at least a 20% overhead.
-                    type: integer
                 required:
-                - name
+                - adminSecret
                 type: object
-              type: array
-            autoscalers:
-              description: Name of active autoscaler resources
-              items:
-                type: string
-              type: array
-            buckets:
-              description: Name of buckets active within cluster
-              items:
+              securityContext:
+                description: 'SecurityContext allows the configuration of the security context for all Couchbase server pods.  When using persistent volumes you may need to set the fsGroup field in order to write to the volume.  For non-root clusters you must also set runAsUser to 1000, corresponding to the Couchbase user in official container images.  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                 properties:
-                  compressionMode:
-                    type: string
-                  conflictResolution:
-                    type: string
-                  enableFlush:
-                    type: boolean
-                  enableIndexReplica:
-                    type: boolean
-                  evictionPolicy:
-                    type: string
-                  ioPriority:
-                    type: string
-                  memoryQuota:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                     format: int64
                     type: integer
-                  name:
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                     type: string
-                  password:
-                    type: string
-                  replicas:
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                    format: int64
                     type: integer
-                  type:
-                    type: string
-                required:
-                - compressionMode
-                - conflictResolution
-                - enableFlush
-                - enableIndexReplica
-                - evictionPolicy
-                - ioPriority
-                - memoryQuota
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this pod.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                        type: string
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
+              serverGroups:
+                description: ServerGroups define the set of availability zones you want to distribute pods over, and construct Couchbase server groups for.  By default, most cloud providers will label nodes with the key "failure-domain.beta.kubernetes.io/zone", the values associated with that key are used here to provide explicit scheduling by the Operator.  You may manually label nodes using the "failure-domain.beta.kubernetes.io/zone" key, to provide failure-domain aware scheduling when none is provided for you.  Global server groups are applied to all server classes, and may be overridden on a per-server class basis to give more control over scheduling and server groups.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              servers:
+                description: Servers defines server classes for the Operator to provision and manage. A server class defines what services are running and how many members make up that class.  Specifying multiple server classes allows the Operator to provision clusters with Multi-Dimensional Scaling (MDS).  At least one server class must be defined, and at least one server class must be running the data service.
+                items:
+                  properties:
+                    autoscaleEnabled:
+                      description: AutoscaledEnabled defines whether the autoscaling feature is enabled for this class. When true, the Operator will create a CouchbaseAutoscaler resource for this server class.  The CouchbaseAutoscaler implements the Kubernetes scale API and can be controlled by the Kubernetes horizontal pod autoscaler (HPA).
+                      type: boolean
+                    env:
+                      description: Env allows the setting of environment variables in the Couchbase server container.
+                      items:
+                        description: EnvVar represents an environment variable present in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value. Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes, optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    envFrom:
+                      description: EnvFrom allows the setting of environment variables in the Couchbase server container.
+                      items:
+                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be defined
+                                type: boolean
+                            type: object
+                          prefix:
+                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                        type: object
+                      type: array
+                    name:
+                      description: Name is a textual name for the server configuration and must be unique. The name is used by the operator to uniquely identify a server class, and map pods back to an intended configuration.
+                      type: string
+                    pod:
+                      description: 'Pod defines a template used to create pod for each Couchbase server instance.  Modifying pod metadata such as labels and annotations will update the pod in-place.  Any other modification will result in a cluster upgrade in order to fulfill the request. The Operator reserves the right to modify or replace any field.  More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pod-v1-core'
+                      properties:
+                        metadata:
+                          description: Standard objects metadata.  This is a curated version for use with Couchbase resource templates.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                              type: object
+                          type: object
+                        spec:
+                          description: PodSpec is a description of a pod.
+                          properties:
+                            activeDeadlineSeconds:
+                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+                              format: int64
+                              type: integer
+                            affinity:
+                              description: If specified, the pod's scheduling constraints
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector terms. The terms are ORed.
+                                          items:
+                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                              type: boolean
+                            dnsConfig:
+                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+                              properties:
+                                nameservers:
+                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+                                  items:
+                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                    properties:
+                                      name:
+                                        description: Required.
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+                              type: string
+                            enableServiceLinks:
+                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                              type: boolean
+                            ephemeralContainers:
+                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
+                              items:
+                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral containers.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral containers.
+                                    items:
+                                      description: ContainerPort represents a network port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: SecurityContext is not allowed for ephemeral containers.
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options.
+                                        properties:
+                                          localhostProfile:
+                                            description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                            type: string
+                                          type:
+                                            description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following should be specified. Exec specifies the action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
+                                    type: string
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside of the container that the device will be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            hostAliases:
+                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
+                              items:
+                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
+                              type: boolean
+                            hostNetwork:
+                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+                              type: boolean
+                            hostPID:
+                              description: 'Use the host''s pid namespace. Optional: Default to false.'
+                              type: boolean
+                            hostname:
+                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+                              type: string
+                            imagePullSecrets:
+                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              items:
+                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                type: object
+                              type: array
+                            nodeName:
+                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
+                              type: object
+                            preemptionPolicy:
+                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                              type: string
+                            priority:
+                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+                              type: string
+                            readinessGates:
+                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                              items:
+                                description: PodReadinessGate contains the reference to a pod condition
+                                properties:
+                                  conditionType:
+                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            restartPolicy:
+                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              type: string
+                            runtimeClassName:
+                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
+                              type: string
+                            schedulerName:
+                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+                              type: string
+                            securityContext:
+                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
+                              properties:
+                                fsGroup:
+                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
+                                  type: string
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: The seccomp options to use by the containers in this pod.
+                                  properties:
+                                    localhostProfile:
+                                      description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                supplementalGroups:
+                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
+                                  items:
+                                    description: Sysctl defines a kernel parameter to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
+                              type: string
+                            serviceAccountName:
+                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              type: string
+                            setHostnameAsFQDN:
+                              description: If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+                              type: boolean
+                            shareProcessNamespace:
+                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
+                              type: boolean
+                            subdomain:
+                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
+                              type: string
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+                              format: int64
+                              type: integer
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,   but giving higher precedence to topologies that would help reduce the   skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assigment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              items:
+                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                                properties:
+                                  awsElasticBlockStore:
+                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    properties:
+                                      fsType:
+                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                        type: string
+                                      partition:
+                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: boolean
+                                      volumeID:
+                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  azureDisk:
+                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                    properties:
+                                      cachingMode:
+                                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                                        type: string
+                                      diskName:
+                                        description: The Name of the data disk in the blob storage
+                                        type: string
+                                      diskURI:
+                                        description: The URI the data disk in the blob storage
+                                        type: string
+                                      fsType:
+                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      kind:
+                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                        type: string
+                                      readOnly:
+                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                    required:
+                                    - diskName
+                                    - diskURI
+                                    type: object
+                                  azureFile:
+                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                    properties:
+                                      readOnly:
+                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretName:
+                                        description: the name of secret that contains Azure Storage Account Name and Key
+                                        type: string
+                                      shareName:
+                                        description: Share Name
+                                        type: string
+                                    required:
+                                    - secretName
+                                    - shareName
+                                    type: object
+                                  cephfs:
+                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                    properties:
+                                      monitors:
+                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        items:
+                                          type: string
+                                        type: array
+                                      path:
+                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                        type: string
+                                      readOnly:
+                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: boolean
+                                      secretFile:
+                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: string
+                                      secretRef:
+                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        type: string
+                                    required:
+                                    - monitors
+                                    type: object
+                                  cinder:
+                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    properties:
+                                      fsType:
+                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: string
+                                      readOnly:
+                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      volumeID:
+                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  configMap:
+                                    description: ConfigMap represents a configMap that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                  csi:
+                                    description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                    properties:
+                                      driver:
+                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                        type: string
+                                      fsType:
+                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                        type: string
+                                      nodePublishSecretRef:
+                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      readOnly:
+                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  downwardAPI:
+                                    description: DownwardAPI represents downward API about the pod that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: Items is a list of downward API volume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  emptyDir:
+                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    properties:
+                                      medium:
+                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    description: "Ephemeral represents a volume that is handled by a cluster storage driver (Alpha feature). The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity    tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through    a PersistentVolumeClaim (see EphemeralVolumeSource for more    information on the connection between this volume type    and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                                    properties:
+                                      readOnly:
+                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                        type: boolean
+                                      volumeClaimTemplate:
+                                        description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
+                                        properties:
+                                          metadata:
+                                            description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                            type: object
+                                          spec:
+                                            description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                            properties:
+                                              accessModes:
+                                                description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                                items:
+                                                  type: string
+                                                type: array
+                                              dataSource:
+                                                description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              resources:
+                                                description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                description: A label query over volumes to consider for binding.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                              storageClassName:
+                                                description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                type: string
+                                              volumeMode:
+                                                description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                                type: string
+                                              volumeName:
+                                                description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - spec
+                                        type: object
+                                    type: object
+                                  fc:
+                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                    properties:
+                                      fsType:
+                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                        type: string
+                                      lun:
+                                        description: 'Optional: FC target lun number'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                        type: boolean
+                                      targetWWNs:
+                                        description: 'Optional: FC target worldwide names (WWNs)'
+                                        items:
+                                          type: string
+                                        type: array
+                                      wwids:
+                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  flexVolume:
+                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                                    properties:
+                                      driver:
+                                        description: Driver is the name of the driver to use for this volume.
+                                        type: string
+                                      fsType:
+                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'Optional: Extra command options if any.'
+                                        type: object
+                                      readOnly:
+                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  flocker:
+                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                    properties:
+                                      datasetName:
+                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                        type: string
+                                      datasetUUID:
+                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    properties:
+                                      fsType:
+                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                        type: string
+                                      partition:
+                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        format: int32
+                                        type: integer
+                                      pdName:
+                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: string
+                                      readOnly:
+                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        type: boolean
+                                    required:
+                                    - pdName
+                                    type: object
+                                  gitRepo:
+                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                                    properties:
+                                      directory:
+                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                        type: string
+                                      repository:
+                                        description: Repository URL
+                                        type: string
+                                      revision:
+                                        description: Commit hash for the specified revision.
+                                        type: string
+                                    required:
+                                    - repository
+                                    type: object
+                                  glusterfs:
+                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                    properties:
+                                      endpoints:
+                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: string
+                                      path:
+                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: string
+                                      readOnly:
+                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        type: boolean
+                                    required:
+                                    - endpoints
+                                    - path
+                                    type: object
+                                  hostPath:
+                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                                    properties:
+                                      path:
+                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        type: string
+                                      type:
+                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  iscsi:
+                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                    properties:
+                                      chapAuthDiscovery:
+                                        description: whether support iSCSI Discovery CHAP authentication
+                                        type: boolean
+                                      chapAuthSession:
+                                        description: whether support iSCSI Session CHAP authentication
+                                        type: boolean
+                                      fsType:
+                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                        type: string
+                                      initiatorName:
+                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                        type: string
+                                      iqn:
+                                        description: Target iSCSI Qualified Name.
+                                        type: string
+                                      iscsiInterface:
+                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                        type: string
+                                      lun:
+                                        description: iSCSI Target Lun number.
+                                        format: int32
+                                        type: integer
+                                      portals:
+                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                        items:
+                                          type: string
+                                        type: array
+                                      readOnly:
+                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                        type: boolean
+                                      secretRef:
+                                        description: CHAP Secret for iSCSI target and initiator authentication
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      targetPortal:
+                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                        type: string
+                                    required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                    type: object
+                                  name:
+                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  nfs:
+                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    properties:
+                                      path:
+                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: string
+                                      readOnly:
+                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: boolean
+                                      server:
+                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                        type: string
+                                    required:
+                                    - path
+                                    - server
+                                    type: object
+                                  persistentVolumeClaim:
+                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    properties:
+                                      claimName:
+                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                        type: string
+                                      readOnly:
+                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  photonPersistentDisk:
+                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      pdID:
+                                        description: ID that identifies Photon Controller persistent disk
+                                        type: string
+                                    required:
+                                    - pdID
+                                    type: object
+                                  portworxVolume:
+                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      volumeID:
+                                        description: VolumeID uniquely identifies a Portworx volume
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  projected:
+                                    description: Items for all in one resources secrets, configmaps, and downward API
+                                    properties:
+                                      defaultMode:
+                                        description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      sources:
+                                        description: list of volume projections
+                                        items:
+                                          description: Projection that may be projected along with other supported volume types
+                                          properties:
+                                            configMap:
+                                              description: information about the configMap data to project
+                                              properties:
+                                                items:
+                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: The key to project.
+                                                        type: string
+                                                      mode:
+                                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap or its keys must be defined
+                                                  type: boolean
+                                              type: object
+                                            downwardAPI:
+                                              description: information about the downwardAPI data to project
+                                              properties:
+                                                items:
+                                                  description: Items is a list of DownwardAPIVolume file
+                                                  items:
+                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                    properties:
+                                                      fieldRef:
+                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                        properties:
+                                                          apiVersion:
+                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                            type: string
+                                                          fieldPath:
+                                                            description: Path of the field to select in the specified API version.
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                      mode:
+                                                        description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                        properties:
+                                                          containerName:
+                                                            description: 'Container name: required for volumes, optional for env vars'
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            description: Specifies the output format of the exposed resources, defaults to "1"
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            description: 'Required: resource to select'
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                              type: object
+                                            secret:
+                                              description: information about the secret data to project
+                                              properties:
+                                                items:
+                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: The key to project.
+                                                        type: string
+                                                      mode:
+                                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                name:
+                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret or its key must be defined
+                                                  type: boolean
+                                              type: object
+                                            serviceAccountToken:
+                                              description: information about the serviceAccountToken data to project
+                                              properties:
+                                                audience:
+                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                                  type: string
+                                                expirationSeconds:
+                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                                  format: int64
+                                                  type: integer
+                                                path:
+                                                  description: Path is the path relative to the mount point of the file to project the token into.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                          type: object
+                                        type: array
+                                    required:
+                                    - sources
+                                    type: object
+                                  quobyte:
+                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                    properties:
+                                      group:
+                                        description: Group to map volume access to Default is no group
+                                        type: string
+                                      readOnly:
+                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                        type: boolean
+                                      registry:
+                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                        type: string
+                                      tenant:
+                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                        type: string
+                                      user:
+                                        description: User to map volume access to Defaults to serivceaccount user
+                                        type: string
+                                      volume:
+                                        description: Volume is a string that references an already created Quobyte volume by name.
+                                        type: string
+                                    required:
+                                    - registry
+                                    - volume
+                                    type: object
+                                  rbd:
+                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                    properties:
+                                      fsType:
+                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                        type: string
+                                      image:
+                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      keyring:
+                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      monitors:
+                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        items:
+                                          type: string
+                                        type: array
+                                      pool:
+                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                      readOnly:
+                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: boolean
+                                      secretRef:
+                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        type: string
+                                    required:
+                                    - image
+                                    - monitors
+                                    type: object
+                                  scaleIO:
+                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                        type: string
+                                      gateway:
+                                        description: The host address of the ScaleIO API Gateway.
+                                        type: string
+                                      protectionDomain:
+                                        description: The name of the ScaleIO Protection Domain for the configured storage.
+                                        type: string
+                                      readOnly:
+                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      sslEnabled:
+                                        description: Flag to enable/disable SSL communication with Gateway, default false
+                                        type: boolean
+                                      storageMode:
+                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                        type: string
+                                      storagePool:
+                                        description: The ScaleIO Storage Pool associated with the protection domain.
+                                        type: string
+                                      system:
+                                        description: The name of the storage system as configured in ScaleIO.
+                                        type: string
+                                      volumeName:
+                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                        type: string
+                                    required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                    type: object
+                                  secret:
+                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    properties:
+                                      defaultMode:
+                                        description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: The key to project.
+                                              type: string
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      optional:
+                                        description: Specify whether the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                        type: object
+                                      volumeName:
+                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                        type: string
+                                      volumeNamespace:
+                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      storagePolicyID:
+                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                        type: string
+                                      storagePolicyName:
+                                        description: Storage Policy Based Management (SPBM) profile name.
+                                        type: string
+                                      volumePath:
+                                        description: Path that identifies vSphere volume vmdk
+                                        type: string
+                                    required:
+                                    - volumePath
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    resources:
+                      description: Resources are the resource requirements for the Couchbase server container. This field overrides any automatic allocation as defined by `spec.autoResourceAllocation`.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    serverGroups:
+                      description: ServerGroups define the set of availability zones you want to distribute pods over, and construct Couchbase server groups for.  By default, most cloud providers will label nodes with the key "failure-domain.beta.kubernetes.io/zone", the values associated with that key are used here to provide explicit scheduling by the Operator.  You may manually label nodes using the "failure-domain.beta.kubernetes.io/zone" key, to provide failure-domain aware scheduling when none is provided for you.  Global server groups are applied to all server classes, and may be overridden on a per-server class basis to give more control over scheduling and server groups.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    services:
+                      description: Services is the set of Couchbase services to run on this server class. At least one class must contain the data service.  The field may contain any of "data", "index", "query", "search", "eventing" or "analytics". Each service may only be specified once.
+                      items:
+                        description: Supported services
+                        enum:
+                        - admin
+                        - data
+                        - index
+                        - query
+                        - search
+                        - eventing
+                        - analytics
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    size:
+                      description: Size is the expected requested of the server class.  This field must be greater than or equal to 1.
+                      minimum: 1
+                      type: integer
+                    volumeMounts:
+                      description: VolumeMounts define persistent volume claims to attach to pod.
+                      properties:
+                        analytics:
+                          description: AnalyticsClaims are persistent volumes that encompass analytics storage associated with the analytics service.  Analytics claims can only be used on server classes running the analytics service, and must be used in conjunction with the default claim. This field allows the analytics service to use different storage media (e.g. SSD), and scale horizontally, to improve performance of this service.  This field references a volume claim template name as defined in "spec.volumeClaimTemplates".
+                          items:
+                            type: string
+                          type: array
+                        data:
+                          description: DataClaim is a persistent volume that encompasses key/value storage associated with the data service.  The data claim can only be used on server classes running the data service, and must be used in conjunction with the default claim.  This field allows the data service to use different storage media (e.g. SSD) to improve performance of this service.  This field references a volume claim template name as defined in "spec.volumeClaimTemplates".
+                          type: string
+                        default:
+                          description: DefaultClaim is a persistent volume that encompasses all Couchbase persistent data, including document storage, indexes and logs.  The default volume can be used with any server class.  Use of the default claim allows the Operator to recover failed pods from the persistent volume far quicker than if the pod were using ephemeral storage.  The default claim cannot be used at the same time as the logs claim within the same server class.  This field references a volume claim template name as defined in "spec.volumeClaimTemplates".
+                          type: string
+                        index:
+                          description: IndexClaim s a persistent volume that encompasses index storage associated with the index and search services.  The index claim can only be used on server classes running the index or search services, and must be used in conjunction with the default claim.  This field allows the index and/or search service to use different storage media (e.g. SSD) to improve performance of this service. This field references a volume claim template name as defined in "spec.volumeClaimTemplates". Whilst this references index primarily, note that the full text search (FTS) service also uses this same mount.
+                          type: string
+                        logs:
+                          description: 'LogsClaim is a persistent volume that encompasses only Couchbase server logs to aid with supporting the product.  The logs claim can only be used on server classes running the following services: query, search & eventing.  The logs claim cannot be used at the same time as the default claim within the same server class.  This field references a volume claim template name as defined in "spec.volumeClaimTemplates". Whilst the logs claim can be used with the search service, the recommendation is to use the default claim for these. The reason for this is that a failure of these nodes will require indexes to be rebuilt and subsequent performance impact.'
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  - services
+                  - size
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
                 - name
-                - password
-                - replicas
-                - type
-                type: object
-              type: array
-            clusterId:
-              description: A unique cluster identifier
-              type: string
-            conditions:
-              description: Condition keeps ten most recent cluster conditions
-              items:
+                x-kubernetes-list-type: map
+              softwareUpdateNotifications:
+                description: SoftwareUpdateNotifications enables software update notifications in the UI. When enabled, the UI will alert when a Couchbase server upgrade is available.
+                type: boolean
+              upgradeStrategy:
+                description: UpgradeStrategy controls how aggressive the Operator is when performing a cluster upgrade.  When a rolling upgrade is requested, pods are upgraded one at a time.  This strategy is slower, however less disruptive.  When an immediate upgrade strategy is requested, all pods are upgraded at the same time.  This strategy is faster, but more disruptive.  This field must be either "RollingUpgrade" or "ImmediateUpgrade", defaulting to "RollingUpgrade".
+                enum:
+                - RollingUpgrade
+                - ImmediateUpgrade
+                type: string
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates define the desired characteristics of a volume that can be requested/claimed by a pod, for example the storage class to use and the volume size.  Volume claim templates are referred to by name by server class volume mount configuration.
+                items:
+                  properties:
+                    metadata:
+                      description: Standard objects metadata.  This is a curated version for use with Couchbase resource templates.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    spec:
+                      description: PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+                      properties:
+                        accessModes:
+                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        resources:
+                          description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        selector:
+                          description: A label query over volumes to consider for binding.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        storageClassName:
+                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                          type: string
+                        volumeName:
+                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                  required:
+                  - metadata
+                  - spec
+                  type: object
+                type: array
+              xdcr:
+                description: XDCR defines whether the Operator should manage XDCR, remote clusters and how to lookup replication resources.
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of condition
-                    enum:
-                    - Available
-                    - Balanced
-                    - ManageConfig
-                    - Scaling
-                    - Upgrading
-                    - Hibernating
-                    type: string
-                required:
-                - status
-                - type
+                  managed:
+                    description: Managed defines whether XDCR is managed by the operator or not.
+                    type: boolean
+                  remoteClusters:
+                    description: RemoteClusters is a set of named remote clusters to establish replications to.
+                    items:
+                      description: RemoteCluster is a reference to a remote cluster for XDCR.
+                      properties:
+                        authenticationSecret:
+                          description: AuthenticationSecret is a secret used to authenticate when establishing a remote connection.  It is only required when not using mTLS.  The secret must contain a username (secret key "username") and password (secret key "password").
+                          type: string
+                        hostname:
+                          description: Hostname is the connection string to use to connect the remote cluster.
+                          pattern: ^((couchbase|couchbases|http|https)://)?[0-9a-zA-Z\-\.]+(:\d+)?(\?network=[^&]+)?$
+                          type: string
+                        name:
+                          description: Name of the remote cluster.
+                          type: string
+                        replications:
+                          description: Replications are replication streams from this cluster to the remote one. This field defines how to look up CouchbaseReplication resources.  By default any CouchbaseReplication resources in the namespace will be considered.
+                          properties:
+                            selector:
+                              description: Selector allows CouchbaseReplication resources to be filtered based on labels.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                          type: object
+                        tls:
+                          description: TLS if specified references a resource containing the necessary certificate data for an encrypted connection.
+                          properties:
+                            secret:
+                              description: Secret references a secret containing the CA certificate (data key "ca"), and optionally a client certificate (data key "certificate") and key (data key "key").
+                              type: string
+                          required:
+                          - secret
+                          type: object
+                        uuid:
+                          description: UUID of the remote cluster.  The UUID of a CouchbaseCluster resource is advertised in the status.clusterId field of the resource.
+                          pattern: ^[0-9a-f]{32}$
+                          type: string
+                      required:
+                      - hostname
+                      - name
+                      - uuid
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                 type: object
-              type: array
-            controlPaused:
-              description: ControlPaused indicates the operator pauses the control
-                of the cluster.
-              type: boolean
-            currentVersion:
-              description: CurrentVersion is the current cluster version
-              type: string
-            groups:
-              description: Name of groups active within cluster
-              items:
+            required:
+            - image
+            - security
+            - servers
+            type: object
+          status:
+            description: ClusterStatus defines any read-only status fields for the Couchbase server cluster.
+            properties:
+              allocations:
+                description: Allocations shows memory allocations within server classes.
+                items:
+                  description: ServerClassStatus summarizes memory allocations to make configuration easier.
+                  properties:
+                    allocatedMemory:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: AllocatedMemory defines the total memory allocated for constrained Couchbase services.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    allocatedMemoryPercent:
+                      description: AllocatedMemoryPercent is set when memory resources are requested and define how much of the requested memory is allocated to constrained Couchbase services.
+                      type: integer
+                    analyticsServiceAllocation:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: AnalyticsServiceAllocation is set when the analytics service is enabled for this class and defines how much memory this service consumes per pod.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    dataServiceAllocation:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: DataServiceAllocation is set when the data service is enabled for this class and defines how much memory this service consumes per pod.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    eventingServiceAllocation:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: EventingServiceAllocation is set when the eventing service is enabled for this class and defines how much memory this service consumes per pod.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    indexServiceAllocation:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: IndexServiceAllocation is set when the index service is enabled for this class and defines how much memory this service consumes per pod.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    name:
+                      description: Name is the name of the server class defined in spec.servers
+                      type: string
+                    requestedMemory:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: RequestedMemory, if set, defines the Kubernetes resource request for the server class.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    searchServiceAllocation:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: SearchServiceAllocation is set when the search service is enabled for this class and defines how much memory this service consumes per pod.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    unusedMemory:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: UnusedMemory is set when memory resources are requested and is the difference between the requestedMemory and allocatedMemory.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      type: string
+                      x-kubernetes-int-or-string: true
+                    unusedMemoryPercent:
+                      description: UnusedMemoryPercent is set when memory resources are requested and defines how much requested memory is not allocated.  Couchbase server expects at least a 20% overhead.
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              autoscalers:
+                description: Autscalers describes all the autoscalers managed by the cluster.
+                items:
+                  type: string
+                type: array
+              buckets:
+                description: Buckets describes all the buckets managed by the cluster.
+                items:
+                  properties:
+                    compressionMode:
+                      description: CompressionMode defines how documents are compressed.
+                      type: string
+                    conflictResolution:
+                      description: ConflictResolution is relevant for `couchbase` and `ephemeral` bucket types and indicates how to resolve conflicts when using multi-master XDCR.
+                      type: string
+                    enableFlush:
+                      description: EnableFlush is whether a client can delete all documents in a bucket.
+                      type: boolean
+                    enableIndexReplica:
+                      description: EnableIndexReplica is whether indexes against bucket documents are replicated.
+                      type: boolean
+                    evictionPolicy:
+                      description: EvictionPolicy is relevant for `couchbase` and `ephemeral` bucket types and indicates how documents are evicted from memory when it is exhausted.
+                      type: string
+                    ioPriority:
+                      description: IoPriority is `low` or `high` depending on the number of threads spawned for data processing.
+                      type: string
+                    memoryQuota:
+                      description: BucketMemoryQuota is the bucket memory quota in megabytes.
+                      format: int64
+                      type: integer
+                    name:
+                      description: BucketName is the full name of the bucket.
+                      type: string
+                    password:
+                      description: BucketPassword will never be populated.
+                      type: string
+                    replicas:
+                      description: BucketReplicas is the number of data replicas.
+                      type: integer
+                    type:
+                      description: BucketType is the type of the bucket.
+                      type: string
+                  required:
+                  - compressionMode
+                  - conflictResolution
+                  - enableFlush
+                  - enableIndexReplica
+                  - evictionPolicy
+                  - ioPriority
+                  - memoryQuota
+                  - name
+                  - password
+                  - replicas
+                  - type
+                  type: object
+                type: array
+              clusterId:
+                description: ClusterID is the unique cluster UUID.  This is generated every time a new cluster is created, so may vary over the lifetime of a cluster if it is recreated by disaster recovery mechanisms.
                 type: string
-              type: array
-            members:
-              description: Members are the couchbase members in the cluster
-              properties:
-                ready:
-                  description: Ready are the couchbase members that are ready to serve
-                    requests The member names are the same as the couchbase pod names
-                  items:
-                    type: string
-                  type: array
-                unready:
-                  description: Unready are the couchbase members not ready to serve
-                    requests
-                  items:
-                    type: string
-                  type: array
-              type: object
-            size:
-              description: Size is the current size of the cluster
-              type: integer
-            users:
-              description: Name of users active within cluster
-              items:
+              conditions:
+                description: Current service state of the Couchbase cluster.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      type: string
+                    lastUpdateTime:
+                      description: Last time the condition status message updated.
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of condition.
+                      enum:
+                      - Available
+                      - Balanced
+                      - ManageConfig
+                      - Scaling
+                      - Upgrading
+                      - Hibernating
+                      - Error
+                      - AutoscaleReady
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPaused:
+                description: ControlPaused indicates if the Operator has acknowledged and paused the control of the cluster.
+                type: boolean
+              currentVersion:
+                description: CurrentVersion is the current Couchbase version.  This reflects the version of the whole cluster, therefore during upgrade, it is only updated when the upgrade has completed.
                 type: string
-              type: array
-          required:
-          - size
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
-  versions:
-  - name: v2
+              groups:
+                description: Groups describes all the groups managed by the cluster.
+                items:
+                  type: string
+                type: array
+              members:
+                description: Members are the Couchbase members in the cluster.
+                properties:
+                  ready:
+                    description: Ready are the Couchbase members that are clustered and ready to serve client requests.  The member names are the same as the Couchbase pod names.
+                    items:
+                      type: string
+                    type: array
+                  unready:
+                    description: Unready are the Couchbase members not clustered or unready to serve client requests.  The member names are the same as the Couchbase pod names.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              size:
+                description: Size is the current size of the cluster in terms of pods.  Individual pod status conditions are listed in the members status.
+                type: integer
+              users:
+                description: Users describes all the users managed by the cluster.
+                items:
+                  type: string
+                type: array
+            required:
+            - size
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbaseephemeralbuckets.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.memoryQuota
-    name: memory quota
-    type: string
-  - JSONPath: .spec.replicas
-    name: replicas
-    type: integer
-  - JSONPath: .spec.ioPriority
-    name: io priority
-    type: string
-  - JSONPath: .spec.evictionPolicy
-    name: eviction policy
-    type: string
-  - JSONPath: .spec.conflictResolution
-    name: conflict resolution
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseEphemeralBucket
@@ -7783,88 +4809,110 @@ spec:
     plural: couchbaseephemeralbuckets
     singular: couchbaseephemeralbucket
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            compressionMode:
-              description: CouchbaseBucketCompressionMode defines the available compression
-                modes for Couchbase and Ephemeral bucket types.
-              enum:
-              - "off"
-              - passive
-              - active
-              type: string
-            conflictResolution:
-              description: CouchbsaeBucketConflictResolution defines the XDCR conflict
-                resolution for a bucket.
-              enum:
-              - seqno
-              - lww
-              type: string
-            enableFlush:
-              type: boolean
-            evictionPolicy:
-              description: CouchbaseEphemeralBucketEvictionPolicy defines the available
-                eviction policies for ephemeral bucket types.
-              enum:
-              - noEviction
-              - nruEviction
-              type: string
-            ioPriority:
-              description: CouchbaseBucketIOPriority defines the priority of a bucket.
-              enum:
-              - low
-              - high
-              type: string
-            maxTTL:
-              type: string
-            memoryQuota:
-              anyOf:
-              - type: integer
-              - type: string
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            minimumDurability:
-              description: CouchbaseEphemeralBucketMinimumDurability is the miniumum
-                durability that writes to a bucket should conform to.  Clients can
-                explicitly write with a stricter policy.
-              enum:
-              - none
-              - majority
-              type: string
-            name:
-              maxLength: 100
-              pattern: ^[a-zA-Z0-9-_%\.]+$
-              type: string
-            replicas:
-              maximum: 3
-              minimum: 0
-              type: integer
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.memoryQuota
+      name: memory quota
+      type: string
+    - jsonPath: .spec.replicas
+      name: replicas
+      type: integer
+    - jsonPath: .spec.ioPriority
+      name: io priority
+      type: string
+    - jsonPath: .spec.evictionPolicy
+      name: eviction policy
+      type: string
+    - jsonPath: .spec.conflictResolution
+      name: conflict resolution
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: The CouchbaseEphemeralBucket resource defines a set of documents in Couchbase server. A Couchbase client connects to and operates on a bucket, which provides independent management of a set documents and a security boundary for role based access control. A CouchbaseEphemeralBucket provides in-memory only storage and replication for documents contained by it.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            default: {}
+            description: CouchbaseEphemeralBucketSpec is the specification for an ephemeral Couchbase bucket resource, and allows the bucket to be customized.
+            properties:
+              compressionMode:
+                default: passive
+                description: CompressionMode defines how Couchbase server handles document compression.  When off, documents are stored in memory, and transferred to the client uncompressed. When passive, documents are stored compressed in memory, and transferred to the client compressed when requested.  When active, documents are stored compresses in memory and when transferred to the client.  This field must be "off", "passive" or "active", defaulting to "passive".  Be aware "off" in YAML 1.2 is a boolean, so must be quoted as a string in configuration files.
+                enum:
+                - "off"
+                - passive
+                - active
+                type: string
+              conflictResolution:
+                default: seqno
+                description: ConflictResolution defines how XDCR handles concurrent write conflicts.  Sequence number based resolution selects the document with the highest sequence number as the most recent. Timestamp based resolution selects the document that was written to most recently as the most recent.  This field must be "seqno" (sequence based), or "lww" (timestamp based), defaulting to "seqno".
+                enum:
+                - seqno
+                - lww
+                type: string
+              enableFlush:
+                description: EnableFlush defines whether a client can delete all documents in a bucket. This field defaults to false.
+                type: boolean
+              evictionPolicy:
+                default: noEviction
+                description: EvictionPolicy controls how Couchbase handles memory exhaustion.  No eviction means that Couchbase server will make this bucket read-only when memory is exhausted in order to avoid data loss.  NRU eviction will delete documents that haven't been used recently in order to free up memory. This field must be "noEviction" or "nruEviction", defaulting to "noEviction".
+                enum:
+                - noEviction
+                - nruEviction
+                type: string
+              ioPriority:
+                default: low
+                description: IOPriority controls how many threads a bucket has, per pod, to process reads and writes. This field must be "low" or "high", defaulting to "low".  Modification of this field will cause a temporary service disruption as threads are restarted.
+                enum:
+                - low
+                - high
+                type: string
+              maxTTL:
+                description: 'MaxTTL defines how long a document is permitted to exist for, without modification, until it is automatically deleted.  This is a default and maximum time-to-live and may be set to a lower value by the client.  If the client specifies a higher value, then it is truncated to the maximum durability.  Documents are removed by Couchbase, after they have expired, when either accessed, the expiry pager is run, or the bucket is compacted.  When set to 0, then documents are not expired by default.  This field must be a duration in the range 0-2147483648s, defaulting to 0.  More info: https://golang.org/pkg/time/#ParseDuration'
+                type: string
+              memoryQuota:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 100Mi
+                description: 'MemoryQuota is a memory limit to the size of a bucket.  When this limit is exceeded, documents will be evicted from memory defined by the eviction policy.  The memory quota is defined per Couchbase pod running the data service.  This field defaults to, and must be greater than or equal to 100Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                type: string
+                x-kubernetes-int-or-string: true
+              minimumDurability:
+                description: MiniumumDurability defines how durable a document write is by default, and can be made more durable by the client.  This feature enables ACID transactions. When none, Couchbase server will respond when the document is in memory, it will become eventually consistent across the cluster.  When majority, Couchbase server will respond when the document is replicated to at least half of the pods running the data service in the cluster.  This field must be either "none" or "majority", defaulting to "none".
+                enum:
+                - none
+                - majority
+                type: string
+              name:
+                description: Name is the name of the bucket within Couchbase server.  By default the Operator will use the `metadata.name` field to define the bucket name.  The `metadata.name` field only supports a subset of the supported character set.  When specified, this field overrides `metadata.name`.  Legal bucket names have a maximum length of 100 characters and may be composed of any character from "a-z", "A-Z", "0-9" and "-_%\.".
+                maxLength: 100
+                pattern: ^[a-zA-Z0-9-_%\.]+$
+                type: string
+              replicas:
+                default: 1
+                description: Replicas defines how many copies of documents Couchbase server maintains.  This directly affects how fault tolerant a Couchbase cluster is.  With a single replica, the cluster can tolerate one data pod going down and still service requests without data loss.  The number of replicas also affect memory use.  With a single replica, the effective memory quota for documents is halved, with two replicas it is one third.  The number of replicas must be between 0 and 3, defaulting to 1.
+                maximum: 3
+                minimum: 0
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -7878,94 +4926,85 @@ spec:
     plural: couchbasegroups
     singular: couchbasegroup
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            ldapGroupRef:
-              description: optional reference to LDAP group
-              type: string
-            roles:
-              description: role identifier
-              items:
-                properties:
-                  bucket:
-                    description: optional bucket name for bucket admin roles
-                    pattern: ^\*$|^[a-zA-Z0-9-_%\.]+$
-                    type: string
-                  name:
-                    description: name of role
-                    enum:
-                    - admin
-                    - cluster_admin
-                    - security_admin
-                    - ro_admin
-                    - replication_admin
-                    - query_external_access
-                    - query_system_catalog
-                    - analytics_reader
-                    - bucket_admin
-                    - views_admin
-                    - fts_admin
-                    - bucket_full_access
-                    - data_reader
-                    - data_writer
-                    - data_dcp_reader
-                    - data_backup
-                    - data_monitoring
-                    - replication_target
-                    - analytics_manager
-                    - views_reader
-                    - fts_searcher
-                    - query_select
-                    - query_update
-                    - query_insert
-                    - query_delete
-                    - query_manage_index
-                    type: string
-                required:
-                - name
-                type: object
-              type: array
-          required:
-          - roles
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
   - name: v2
+    schema:
+      openAPIV3Schema:
+        description: CouchbaseGroup allows the automation of Couchbase group management.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseGroupSpec allows the specification of Couchbase group configuration.
+            properties:
+              ldapGroupRef:
+                description: LDAPGroupRef is a reference to an LDAP group.
+                type: string
+              roles:
+                description: Roles is a list of roles that this group is granted.
+                items:
+                  properties:
+                    bucket:
+                      description: Bucket name for bucket admin roles.  When not specified for a role that can be scoped to a specific bucket, the role will apply to all buckets in the cluster.
+                      pattern: ^\*$|^[a-zA-Z0-9-_%\.]+$
+                      type: string
+                    name:
+                      description: Name of role.
+                      enum:
+                      - admin
+                      - cluster_admin
+                      - security_admin
+                      - ro_admin
+                      - replication_admin
+                      - query_external_access
+                      - query_system_catalog
+                      - analytics_reader
+                      - bucket_admin
+                      - views_admin
+                      - fts_admin
+                      - bucket_full_access
+                      - data_reader
+                      - data_writer
+                      - data_dcp_reader
+                      - data_backup
+                      - data_monitoring
+                      - replication_target
+                      - analytics_manager
+                      - views_reader
+                      - fts_searcher
+                      - query_select
+                      - query_update
+                      - query_insert
+                      - query_delete
+                      - query_manage_index
+                      - mobile_sync_gateway
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - roles
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbasememcachedbuckets.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.memoryQuota
-    name: memory quota
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseMemcachedBucket
@@ -7973,65 +5012,60 @@ spec:
     plural: couchbasememcachedbuckets
     singular: couchbasememcachedbucket
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            enableFlush:
-              type: boolean
-            memoryQuota:
-              anyOf:
-              - type: integer
-              - type: string
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            name:
-              maxLength: 100
-              pattern: ^[a-zA-Z0-9-_%\.]+$
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.memoryQuota
+      name: memory quota
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: The CouchbaseMemcachedBucket resource defines a set of documents in Couchbase server. A Couchbase client connects to and operates on a bucket, which provides independent management of a set documents and a security boundary for role based access control. A CouchbaseEphemeralBucket provides in-memory only storage for documents contained by it.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            default: {}
+            description: CouchbaseMemcachedBucketSpec is the specification for a Memcached bucket resource, and allows the bucket to be customized.
+            properties:
+              enableFlush:
+                description: EnableFlush defines whether a client can delete all documents in a bucket. This field defaults to false.
+                type: boolean
+              memoryQuota:
+                anyOf:
+                - type: integer
+                - type: string
+                default: 100Mi
+                description: 'MemoryQuota is a memory limit to the size of a bucket. The memory quota is defined per Couchbase pod running the data service.  This field defaults to, and must be greater than or equal to 100Mi.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                type: string
+                x-kubernetes-int-or-string: true
+              name:
+                description: Name is the name of the bucket within Couchbase server.  By default the Operator will use the `metadata.name` field to define the bucket name.  The `metadata.name` field only supports a subset of the supported character set.  When specified, this field overrides `metadata.name`.  Legal bucket names have a maximum length of 100 characters and may be composed of any character from "a-z", "A-Z", "0-9" and "-_%\.".
+                maxLength: 100
+                pattern: ^[a-zA-Z0-9-_%\.]+$
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.8
   name: couchbasereplications.couchbase.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.bucket
-    name: bucket
-    type: string
-  - JSONPath: .spec.remoteBucket
-    name: remote bucket
-    type: string
-  - JSONPath: .spec.paused
-    name: paused
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: couchbase.com
   names:
     kind: CouchbaseReplication
@@ -8039,59 +5073,70 @@ spec:
     plural: couchbasereplications
     singular: couchbasereplication
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            bucket:
-              description: Bucket is the source bucket to replicate from.  This must
-                be defined and selected by the cluster.
-              maxLength: 100
-              pattern: ^[a-zA-Z0-9-_%\.]+$
-              type: string
-            compressionType:
-              description: CompressionType is the type of compression to apply to
-                the replication.
-              enum:
-              - None
-              - Auto
-              type: string
-            filterExpression:
-              description: FilterExpression allows certain documents to be filtered
-                out of the replication.
-              type: string
-            paused:
-              description: Paused allows a replication to be stopped and restarted.
-              type: boolean
-            remoteBucket:
-              description: RemoteBucket is the remote bucket name to synchronize to.
-              maxLength: 100
-              pattern: ^[a-zA-Z0-9-_%\.]+$
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
-  - name: v2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.bucket
+      name: bucket
+      type: string
+    - jsonPath: .spec.remoteBucket
+      name: remote bucket
+      type: string
+    - jsonPath: .spec.paused
+      name: paused
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v2
+    schema:
+      openAPIV3Schema:
+        description: The CouchbaseReplication resource represents a Couchbase-to-Couchbase, XDCR replication stream from a source bucket to a destination bucket.  This provides off-site backup, migration, and disaster recovery.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseReplicationSpec allows configuration of an XDCR replication.
+            properties:
+              bucket:
+                description: Bucket is the source bucket to replicate from.  This refers to the Couchbase bucket name, not the resource name of the bucket.  A bucket with this name must be defined on this cluster.  Legal bucket names have a maximum length of 100 characters and may be composed of any character from "a-z", "A-Z", "0-9" and "-_%\.".
+                maxLength: 100
+                pattern: ^[a-zA-Z0-9-_%\.]+$
+                type: string
+              compressionType:
+                default: Auto
+                description: CompressionType is the type of compression to apply to the replication. When None, no compression will be applied to documents as they are transferred between clusters.  When Auto, Couchbase server will automatically compress documents as they are transferred to reduce bandwidth requirements. This field must be one of "None" or "Auto", defaulting to "Auto".
+                enum:
+                - None
+                - Auto
+                type: string
+              filterExpression:
+                description: FilterExpression allows certain documents to be filtered out of the replication.
+                type: string
+              paused:
+                description: Paused allows a replication to be stopped and restarted without having to restart the replication from the beginning.
+                type: boolean
+              remoteBucket:
+                description: RemoteBucket is the remote bucket name to synchronize to.  This refers to the Couchbase bucket name, not the resource name of the bucket.  Legal bucket names have a maximum length of 100 characters and may be composed of any character from "a-z", "A-Z", "0-9" and "-_%\.".
+                maxLength: 100
+                pattern: ^[a-zA-Z0-9-_%\.]+$
+                type: string
+            required:
+            - bucket
+            - remoteBucket
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8105,65 +5150,66 @@ spec:
     plural: couchbaserolebindings
     singular: couchbaserolebinding
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            roleRef:
-              description: CouchbaseGroup being bound to subjects
-              properties:
-                kind:
-                  description: Kind of role to use for binding
-                  type: string
-                name:
-                  description: Name of role resource to use for binding
-                  type: string
-              required:
-              - kind
-              - name
-              type: object
-            subjects:
-              description: ' List of users to bind a role to'
-              items:
+  versions:
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        description: CouchbaseRoleBinding allows association of Couchbase users with groups.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseRoleBindingSpec defines the group of subjects i.e. users, and the role i.e. group they are a member of.
+            properties:
+              roleRef:
+                description: CouchbaseGroup being bound to subjects.
                 properties:
                   kind:
-                    description: Couchbase user/group kind
+                    description: Kind of role to use for binding.
+                    enum:
+                    - CouchbaseGroup
                     type: string
                   name:
-                    description: Name of Couchbase user resource
+                    description: Name of role resource to use for binding.
                     type: string
                 required:
                 - kind
                 - name
                 type: object
-              type: array
-          required:
-          - roleRef
-          - subjects
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
-  versions:
-  - name: v2
+              subjects:
+                description: List of users to bind a role to.
+                items:
+                  properties:
+                    kind:
+                      description: Couchbase user/group kind.
+                      enum:
+                      - CouchbaseUser
+                      type: string
+                    name:
+                      description: Name of Couchbase user resource.
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+            required:
+            - roleRef
+            - subjects
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8177,43 +5223,40 @@ spec:
     plural: couchbaseusers
     singular: couchbaseuser
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            authDomain:
-              description: The domain which provides user auth
-              enum:
-              - local
-              - external
-              type: string
-            authSecret:
-              description: Name of kubernetes secret with password for couchbase domain
-              type: string
-            fullName:
-              description: (Optional) Full Name of Couchbase user
-              type: string
-          required:
-          - authDomain
-          type: object
-      required:
-      - spec
-      type: object
-  version: v2
   versions:
   - name: v2
+    schema:
+      openAPIV3Schema:
+        description: CouchbaseUser allows the automation of Couchbase user management.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CouchbaseUserSpec allows the specification of Couchbase user configuration.
+            properties:
+              authDomain:
+                description: The domain which provides user authentication.
+                enum:
+                - local
+                - external
+                type: string
+              authSecret:
+                description: Name of Kubernetes secret with password for Couchbase domain.
+                type: string
+              fullName:
+                description: Full Name of Couchbase user.
+                type: string
+            required:
+            - authDomain
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true

--- a/couchbase-operator/crds/couchbase.crds.yaml
+++ b/couchbase-operator/crds/couchbase.crds.yaml
@@ -183,7 +183,7 @@ spec:
                 type: object
               logRetention:
                 default: 168h
-                description: Number of hours to hold restore script logs for, everything older will be deleted.
+                description: 'Number of hours to hold restore script logs for, everything older will be deleted. More info: https://golang.org/pkg/time/#ParseDuration'
                 type: string
               repo:
                 description: Repo is the backup folder to restore from.
@@ -273,7 +273,7 @@ spec:
                   type: object
                 type: array
               duration:
-                description: Duration tells us how long the last restore took.
+                description: 'Duration tells us how long the last restore took.  More info: https://golang.org/pkg/time/#ParseDuration'
                 type: string
               failed:
                 description: Failed indicates whether the most recent restore has failed.
@@ -384,7 +384,7 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: Limit imposes a hard limit on the size we can autoscale to.  When not specified no bounds are imposed.
+                    description: 'Limit imposes a hard limit on the size we can autoscale to.  When not specified no bounds are imposed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     type: string
                     x-kubernetes-int-or-string: true
@@ -402,7 +402,7 @@ spec:
                 type: integer
               backupRetention:
                 default: 720h
-                description: Number of hours to hold backups for, everything older will be deleted.
+                description: 'Number of hours to hold backups for, everything older will be deleted.  More info: https://golang.org/pkg/time/#ParseDuration'
                 type: string
               failedJobsHistoryLimit:
                 default: 3
@@ -430,7 +430,7 @@ spec:
                 type: object
               logRetention:
                 default: 168h
-                description: Number of hours to hold script logs for, everything older will be deleted.
+                description: 'Number of hours to hold script logs for, everything older will be deleted.  More info: https://golang.org/pkg/time/#ParseDuration'
                 type: string
               s3bucket:
                 description: Name of S3 bucket to backup to. If non-empty this overrides local backup.
@@ -440,7 +440,7 @@ spec:
                 - type: integer
                 - type: string
                 default: 20Gi
-                description: Size allows the specification of a backup persistent volume, when using volume based backup.
+                description: 'Size allows the specification of a backup persistent volume, when using volume based backup. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 type: string
                 x-kubernetes-int-or-string: true
@@ -497,7 +497,7 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: CapacityUsed tells us how much of the PVC we are using.
+                description: 'CapacityUsed tells us how much of the PVC we are using. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 type: string
                 x-kubernetes-int-or-string: true
@@ -505,7 +505,7 @@ spec:
                 description: Cronjob tells us which Cronjob the job belongs to.
                 type: string
               duration:
-                description: Duration tells us how long the last backup took.
+                description: 'Duration tells us how long the last backup took.  More info: https://golang.org/pkg/time/#ParseDuration'
                 type: string
               failed:
                 description: Failed indicates whether the most recent backup has failed.
@@ -1104,7 +1104,7 @@ spec:
                         - type: integer
                         - type: string
                         default: 5Gi
-                        description: TemporarySpace allows the temporary storage used by the query service backfill, per-pod, to be modified.  This field requires `backfillEnabled` to be set to true in order to have any effect.
+                        description: 'TemporarySpace allows the temporary storage used by the query service backfill, per-pod, to be modified.  This field requires `backfillEnabled` to be set to true in order to have any effect. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         type: string
                         x-kubernetes-int-or-string: true
@@ -1116,7 +1116,7 @@ spec:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: QueryServiceMemQuota is a dummy field.  By default, Couchbase server provides no memory resource constrints for the query service, so this has no effect on Couchbase server.  It is, however, used when the spec.autoResourceAllocation feature is enabled, and is used to define the amount of memory reserved by the query service for use with Kubernetes resource scheduling.
+                    description: 'QueryServiceMemQuota is a dummy field.  By default, Couchbase server provides no memory resource constrints for the query service, so this has no effect on Couchbase server.  It is, however, used when the spec.autoResourceAllocation feature is enabled, and is used to define the amount of memory reserved by the query service for use with Kubernetes resource scheduling. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     type: string
                     x-kubernetes-int-or-string: true
@@ -1226,7 +1226,7 @@ spec:
                             - type: integer
                             - type: string
                             default: 20Mi
-                            description: Size allows the specification of a rotation size for the log, defaults to 20Mi.
+                            description: 'Size allows the specification of a rotation size for the log, defaults to 20Mi. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             type: string
                             x-kubernetes-int-or-string: true
@@ -4584,7 +4584,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: AllocatedMemory defines the total memory allocated for constrained Couchbase services.
+                      description: 'AllocatedMemory defines the total memory allocated for constrained Couchbase services. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4595,7 +4595,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: AnalyticsServiceAllocation is set when the analytics service is enabled for this class and defines how much memory this service consumes per pod.
+                      description: 'AnalyticsServiceAllocation is set when the analytics service is enabled for this class and defines how much memory this service consumes per pod.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4603,7 +4603,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: DataServiceAllocation is set when the data service is enabled for this class and defines how much memory this service consumes per pod.
+                      description: 'DataServiceAllocation is set when the data service is enabled for this class and defines how much memory this service consumes per pod.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4611,7 +4611,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: EventingServiceAllocation is set when the eventing service is enabled for this class and defines how much memory this service consumes per pod.
+                      description: 'EventingServiceAllocation is set when the eventing service is enabled for this class and defines how much memory this service consumes per pod.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4619,7 +4619,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: IndexServiceAllocation is set when the index service is enabled for this class and defines how much memory this service consumes per pod.
+                      description: 'IndexServiceAllocation is set when the index service is enabled for this class and defines how much memory this service consumes per pod.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4630,7 +4630,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: RequestedMemory, if set, defines the Kubernetes resource request for the server class.
+                      description: 'RequestedMemory, if set, defines the Kubernetes resource request for the server class. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4638,7 +4638,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: SearchServiceAllocation is set when the search service is enabled for this class and defines how much memory this service consumes per pod.
+                      description: 'SearchServiceAllocation is set when the search service is enabled for this class and defines how much memory this service consumes per pod.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true
@@ -4646,7 +4646,7 @@ spec:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: UnusedMemory is set when memory resources are requested and is the difference between the requestedMemory and allocatedMemory.
+                      description: 'UnusedMemory is set when memory resources are requested and is the difference between the requestedMemory and allocatedMemory.  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes'
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       type: string
                       x-kubernetes-int-or-string: true

--- a/couchbase-operator/templates/NOTES.txt
+++ b/couchbase-operator/templates/NOTES.txt
@@ -20,9 +20,10 @@ A license for Couchbase Server Enterprise Edition is required to use the Helm Ch
 {{- if .Values.install.couchbaseCluster }}
 
 {{- if .Values.cluster.logging.server.enabled }}
+
 == Couchbase-operator server log management deployed.
    # Check the couchbase server logs
-   kubectl logs -f deployment/{{ (include "couchbase-cluster.clustername" .) }}  --namespace {{ .Release.Namespace }}
+   kubectl  --namespace {{ .Release.Namespace }} logs -f {{ printf "%s-0000" (include "couchbase-cluster.clustername" .) }} logging
 {{- end }}
 
 == Connect to Admin console

--- a/couchbase-operator/templates/NOTES.txt
+++ b/couchbase-operator/templates/NOTES.txt
@@ -19,6 +19,12 @@ A license for Couchbase Server Enterprise Edition is required to use the Helm Ch
 
 {{- if .Values.install.couchbaseCluster }}
 
+{{- if (include "couchbase-cluster.logging.server.enabled" .) }}
+== Couchbase-operator server log management deployed.
+   # Check the couchbase server logs
+   kubectl logs -f deployment/{{ (include "couchbase-cluster.clustername" .) }}  --namespace {{ .Release.Namespace }}
+{{- end }}
+
 == Connect to Admin console
 {{- if (include "couchbase-cluster.tls.enabled" .) }}
 {{- if .Values.cluster.networking.dns }}

--- a/couchbase-operator/templates/NOTES.txt
+++ b/couchbase-operator/templates/NOTES.txt
@@ -19,7 +19,7 @@ A license for Couchbase Server Enterprise Edition is required to use the Helm Ch
 
 {{- if .Values.install.couchbaseCluster }}
 
-{{- if (include "couchbase-cluster.logging.server.enabled" .) }}
+{{- if .Values.cluster.logging.server.enabled }}
 == Couchbase-operator server log management deployed.
    # Check the couchbase server logs
    kubectl logs -f deployment/{{ (include "couchbase-cluster.clustername" .) }}  --namespace {{ .Release.Namespace }}

--- a/couchbase-operator/templates/admission-deployment.yaml
+++ b/couchbase-operator/templates/admission-deployment.yaml
@@ -123,11 +123,10 @@ spec:
         command:
         - couchbase-operator-admission
         args:
-          - "--logtostderr"
-          - "--stderrthreshold"
-          - "0"
-          - "-v"
-          - {{if .Values.admissionController.verboseLogging }} "1" {{else}} "0" {{end}}
+          - "--zap-stacktrace-level"
+          - "error"
+          - "--zap-log-level"
+          - {{if .Values.admissionController.verboseLogging }} "debug" {{else}} "info" {{end}}
           - "--tls-cert-file"
           - "/var/run/secrets/couchbase.com/couchbase-operator-admission/tls-cert-file"
           - "--tls-private-key-file"

--- a/couchbase-operator/templates/couchbase-bucket.yaml
+++ b/couchbase-operator/templates/couchbase-bucket.yaml
@@ -14,7 +14,7 @@ items:
     labels:
       cluster: {{ include "couchbase-cluster.clustername" $rootScope }}
   spec:
-{{ toYaml $spec | indent 4 }}
+{{ omit $spec "kind" | toYaml | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/couchbase-operator/templates/couchbase-cluster.yaml
+++ b/couchbase-operator/templates/couchbase-cluster.yaml
@@ -117,6 +117,4 @@ spec:
 {{ toYaml .Values.cluster.securityContext | indent 4 }}
   volumeClaimTemplates:
 {{ toYaml .Values.cluster.volumeClaimTemplates | indent 4 }}
-  logRetentionTime: {{ .Values.cluster.logRetentionTime }}
-  logRetentionCount: {{ .Values.cluster.logRetentionCount }}
 {{- end -}}

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -92,7 +92,7 @@ cluster:
   # name of the cluster. defaults to name of chart release
   name:
   # image is the base couchbase image and version of the couchbase cluster
-  image: "couchbase/server:enterprise-6.6.1"
+  image: "couchbase/server:enterprise-6.6.2"
   # guarantees that the pods in the same cluster are unable to be scheduled on the same node
   antiAffinity: false
   upgradeStrategy: RollingUpgrade
@@ -151,10 +151,6 @@ cluster:
     # a service that exposes the administrator console. This field allows the definition of a
     # base Service resource. The Operator will merge any configuration it controls on top of this template.
     adminConsoleServiceTemplate: {}
-  # The retention period that log volumes are kept for after their associated pods have been deleted.
-  logRetentionTime: 604800s
-  # The maximum number of log volumes that can be kept after their associated pods have been deleted.
-  logRetentionCount: 20
   # xdcr defines remote clusters and replications to them.
   xdcr:
     # managed defines whether the Operator should manage XDCR remote clusters
@@ -225,14 +221,67 @@ cluster:
       # start: 02:00
       # end: 06:00
       # abortCompactionOutsideWindow: true
-
-  # configuration of logging functionality
-  # for use in conjuction with logs persistent volume mount
+  # Configuration of logging functionality in the operator and server
   logging:
     # retention period that log volumes are kept after pods have been deleted
     logRetentionTime: 604800s
     # the maximum number of log volumes that can be kept after pods have been deleted
     logRetentionCount: 20
+    # The following are all related to Couchbase Server log management
+    server:
+      # Optionally enable the log processing and forwarding sidecar
+      enabled: false
+      # Indicate whether the operator should manage the configuration
+      manageConfiguration: true
+      # The name of the Secret used to provide the configuration
+      configurationName: fluent-bit-config
+      # All specific configuration for the sidecar
+      sidecar:
+        # The image to be used to run with logging as a sidecar.
+        image: couchbase/fluent-bit:1.0.0
+        # The location to mount the configurationName Secret into the image.
+        # Useful if image is changed and the new one uses a different location.
+        configurationMountPath: /fluent-bit/config/
+        # Resource limit to apply to the container
+        resources: {} 
+    # The following section covers configuring audit logging for Couchbase Server
+    audit:
+      # Optionally enable audit configuration in the operator
+      enabled: false
+      # The list of event ids (as integers) to disable for auditing purposes.
+      # This is passed to the REST API with no verification by the operator.
+      # Refer to the documentation for details:
+      # https://docs.couchbase.com/server/current/audit-event-reference/audit-event-reference.html
+      disabledEvents: []
+      # The list of users (as strings) to ignore for auditing purposes.
+      # This is passed to the REST API with minimal validation it meets an acceptable regex pattern.
+      # Refer to the documentation for full details on how to configure this:
+      # https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html#ignoring-events-by-user
+      disabledUsers: []
+      # The interval to optionally rotate the audit log.
+      # This is passed to the REST API, see here for details:
+      # https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html
+      rotation:
+        # The interval at which to rotate audit log files, defaults to 15 minutes.
+        interval: 15m
+        # Size allows the specification of a rotation size for the log, defaults to 20Mi.
+        size: 20Mi
+      # Handle all optional garbage collection (GC) configuration for the audit functionality.
+      # This is not part of the audit REST API, it is intended to handle GC automatically for the audit logs.
+      # By default the Couchbase Server rotates the audit logs but does not clean up the rotated logs.
+      # This is left as an operation for the cluster administrator to manage, the operator allows for us to automate this:
+      # https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html      
+      garbageCollection:
+        # Optionally enable the audit cleanup sidecar
+        enabled: false
+        # Image is the image to be used to run the audit sidecar helper.
+        image: busybox:1.32.1
+        # The minimum age of rotated log files to remove, defaults to one hour.
+        age: 1h
+        # The interval at which to check for rotated log files to remove, defaults to 20 minutes.
+        interval: 20m
+        # Resource limit to apply to the container
+        resources: {} 
   # kubernetes security context applied to pods
   securityContext:
     # fsGroup of persistent volume mount
@@ -275,7 +324,7 @@ cluster:
 # disable default bucket creation by setting
 # buckets.default: null
 #
-# setting default to null throws warning https://github.com/helm/helm/issues/5184
+# setting default to null can throw warning https://github.com/helm/helm/issues/5184
 buckets:
   # A bucket to create by default
   default:

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -230,6 +230,7 @@ cluster:
     # The following are all related to Couchbase Server log management
     server:
       # Optionally enable the log processing and forwarding sidecar
+      # To enable this we also need a default or log persistent volume for each server
       enabled: false
       # Indicate whether the operator should manage the configuration
       manageConfiguration: true
@@ -284,6 +285,7 @@ cluster:
           # Resource limit to apply to the container
           resources: {} 
   # kubernetes security context applied to pods
+  # We default to non-root usage, override or remove by setting to null (--set cluster.securityContext=null)
   securityContext:
     # fsGroup of persistent volume mount
     fsGroup: 1000
@@ -308,16 +310,27 @@ cluster:
         - eventing
       # Defines whether Autoscale is permitted for this specific server configuration.
       autoscaleEnabled: false
-      # volume claims to use for persistent storage
-      volumeMounts: {}
       # ServerGroups define the set of availability zones we want to distribute pods over.
       serverGroups: []
       # Pod defines the policy to create pod for the couchbase pod.
       pod:
         spec: {}
+      # volume claims to use for persistent storage
+      volumeMounts: {}
   # VolumeClaimTemplates define the desired characteristics of a volume
   # that can be requested and claimed by a pod.
   volumeClaimTemplates: []
+  # As an example to support the logging sidecar, uncomment the following and comment out the defaults above:
+  #     volumeMounts:
+  #       default: couchbase 
+  # volumeClaimTemplates: 
+  # - metadata:
+  #     name: couchbase 
+  #   spec:
+  #     storageClassName: standard 
+  #     resources: 
+  #       requests:
+  #         storage: 1Gi
 
 # couchbase buckets to create
 # disable default bucket creation by setting

--- a/couchbase-operator/values.yaml
+++ b/couchbase-operator/values.yaml
@@ -20,7 +20,7 @@ couchbaseOperator:
   # image config
   image:
     repository: couchbase/operator
-    tag: 2.1.0
+    tag: 2.2.0
   imagePullPolicy: IfNotPresent
   # imagePullSecrets is an optional list of references to secrets  to use for pulling images
   imagePullSecrets: []
@@ -43,7 +43,7 @@ admissionController:
   name: "couchbase-admission-controller"
   image:
     repository: couchbase/admission-controller
-    tag: 2.1.0
+    tag: 2.2.0
   imagePullPolicy: IfNotPresent
   # imagePullSecrets is an optional list of references to secrets to use for pulling images
   imagePullSecrets: []
@@ -272,16 +272,17 @@ cluster:
       # This is left as an operation for the cluster administrator to manage, the operator allows for us to automate this:
       # https://docs.couchbase.com/server/current/manage/manage-security/manage-auditing.html      
       garbageCollection:
-        # Optionally enable the audit cleanup sidecar
-        enabled: false
-        # Image is the image to be used to run the audit sidecar helper.
-        image: busybox:1.32.1
-        # The minimum age of rotated log files to remove, defaults to one hour.
-        age: 1h
-        # The interval at which to check for rotated log files to remove, defaults to 20 minutes.
-        interval: 20m
-        # Resource limit to apply to the container
-        resources: {} 
+        sidecar:
+          # Optionally enable the audit cleanup sidecar
+          enabled: false
+          # Image is the image to be used to run the audit sidecar helper.
+          image: busybox:1.32.1
+          # The minimum age of rotated log files to remove, defaults to one hour.
+          age: 1h
+          # The interval at which to check for rotated log files to remove, defaults to 20 minutes.
+          interval: 20m
+          # Resource limit to apply to the container
+          resources: {} 
   # kubernetes security context applied to pods
   securityContext:
     # fsGroup of persistent volume mount
@@ -306,7 +307,6 @@ cluster:
         - analytics
         - eventing
       # Defines whether Autoscale is permitted for this specific server configuration.
-      # Only `query` service is allowed to be defined unless `enablePreviewScaling` is set.
       autoscaleEnabled: false
       # volume claims to use for persistent storage
       volumeMounts: {}
@@ -314,8 +314,7 @@ cluster:
       serverGroups: []
       # Pod defines the policy to create pod for the couchbase pod.
       pod:
-        spec:
-          containers: []
+        spec: {}
   # VolumeClaimTemplates define the desired characteristics of a volume
   # that can be requested and claimed by a pod.
   volumeClaimTemplates: []


### PR DESCRIPTION
Added the new logging sidecar support along with the relevant customisation options in the Helm chart.
Updated with the latest CRD contents, note this introduces a change to stable CRDs as well so highlighted some issues with the spec management for buckets which have been resolved.
Updated admission controller launch parameters to be correct based on Zap logging.