### PR TITLE
K8S-2323: Fix bucket creation

### DIFF
--- a/charts/couchbase-operator/Chart.yaml
+++ b/charts/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.2.005
+version: 2.2.006
 appVersion: 2.2.0
 type: application
 keywords:

--- a/charts/couchbase-operator/Chart.yaml
+++ b/charts/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.2.006
+version: 2.2.007
 appVersion: 2.2.0
 type: application
 keywords:

--- a/charts/couchbase-operator/templates/couchbase-bucket.yaml
+++ b/charts/couchbase-operator/templates/couchbase-bucket.yaml
@@ -18,7 +18,7 @@ items:
   spec:
 
 {{/* Remove index replica for Ephemeral Type */}}
-{{- if (eq $spec.kind "CouchbaseEphemeralBucket")  -}}
+{{- if eq (default $spec.kind "CouchbaseBucket") "CouchbaseEphemeralBucket") -}}
 {{- $spec := unset $spec "enableIndexReplica" -}}
 {{- end -}}
 {{ omit $spec "kind" | toYaml | indent 4 }}

--- a/charts/couchbase-operator/templates/couchbase-bucket.yaml
+++ b/charts/couchbase-operator/templates/couchbase-bucket.yaml
@@ -18,7 +18,7 @@ items:
   spec:
 
 {{/* Remove index replica for Ephemeral Type */}}
-{{- if eq (default $spec.kind "CouchbaseBucket") "CouchbaseEphemeralBucket") -}}
+{{- if eq (default $spec.kind "CouchbaseBucket") "CouchbaseEphemeralBucket" -}}
 {{- $spec := unset $spec "enableIndexReplica" -}}
 {{- end -}}
 {{ omit $spec "kind" | toYaml | indent 4 }}


### PR DESCRIPTION
This fix will allow us to avoid this error when we don't use Ephemral bucket in our helm chart

Error: template: couchbase-operator/templates/couchbase-bucket.yaml:19:8: executing "couchbase-operator/templates/couchbase-bucket.yaml" at <eq $spec.kind "CouchbaseEphemeralBucket">: error calling eq: incompatible types for comparison