### PR TITLE
Add unittests for operator and admission controller

### DIFF
--- a/charts/couchbase-operator/templates/admission-deployment.yaml
+++ b/charts/couchbase-operator/templates/admission-deployment.yaml
@@ -1,6 +1,73 @@
 {{- if .Values.install.admissionController }}
 {{ $tls := fromYaml ( include "admission-controller.gen-certs" . ) }}
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "admission-controller.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "admission-controller.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "couchbase-operator.chart" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "admission-controller.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "admission-controller.name" . }}
+      annotations:
+        checksum/config: {{ printf "%s%s" $tls.clientCert $tls.clientKey | sha256sum }}
+    spec:
+      imagePullSecrets:
+      {{- range .Values.admissionController.imagePullSecrets }}
+      - name: "{{ . }}"
+      {{- end }}
+      {{- with .Values.admissionController.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.admissionController.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      volumes:
+      - name: couchbase-operator-admission
+        secret:
+          secretName: {{ template "admission-controller.secret.name" . }}
+      securityContext:
+        runAsNonRoot: {{ .Values.admissionController.runAsNonRoot }}
+      serviceAccountName:  {{ template "admission-controller.fullname" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag }}"
+        imagePullPolicy: {{ .Values.admissionController.imagePullPolicy }}
+        command:
+        - couchbase-operator-admission
+        args:
+          - "--zap-log-level"
+          - {{if .Values.admissionController.verboseLogging }} "debug" {{else}} "info" {{end}}
+          - "--tls-cert-file"
+          - "/var/run/secrets/couchbase.com/couchbase-operator-admission/tls-cert-file"
+          - "--tls-private-key-file"
+          - "/var/run/secrets/couchbase.com/couchbase-operator-admission/tls-private-key-file"
+          {{- range $key, $value := .Values.admissionController.commandArgs }}
+          - "--{{ $key }}={{ $value }}"
+          {{- end }}
+        ports:
+        - name: https
+          containerPort: {{ .Values.admissionService.port }}
+        resources:
+{{ toYaml .Values.admissionController.resources | indent 12 }}
+        volumeMounts:
+        - name: couchbase-operator-admission
+          mountPath: "/var/run/secrets/couchbase.com/couchbase-operator-admission"
+          readOnly: true
+
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -102,72 +169,6 @@ webhooks:
     caBundle: {{ $tls.caCert }}
 {{- end }}
 
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "admission-controller.fullname" . }}
-  labels:
-    app.kubernetes.io/name: {{ include "admission-controller.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "couchbase-operator.chart" . }}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "admission-controller.name" . }}
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: {{ template "admission-controller.name" . }}
-      annotations:
-        checksum/config: {{ printf "%s%s" $tls.clientCert $tls.clientKey | sha256sum }}
-    spec:
-      imagePullSecrets:
-      {{- range .Values.admissionController.imagePullSecrets }}
-      - name: "{{ . }}"
-      {{- end }}
-      {{- with .Values.admissionController.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
-      {{- with .Values.admissionController.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-      {{- end }}
-      volumes:
-      - name: couchbase-operator-admission
-        secret:
-          secretName: {{ template "admission-controller.secret.name" . }}
-      securityContext:
-        runAsNonRoot: {{ .Values.admissionController.runAsNonRoot }}
-      serviceAccountName:  {{ template "admission-controller.fullname" . }}
-      containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.admissionController.image.repository }}:{{ .Values.admissionController.image.tag }}"
-        imagePullPolicy: {{ .Values.admissionController.imagePullPolicy }}
-        command:
-        - couchbase-operator-admission
-        args:
-          - "--zap-log-level"
-          - {{if .Values.admissionController.verboseLogging }} "debug" {{else}} "info" {{end}}
-          - "--tls-cert-file"
-          - "/var/run/secrets/couchbase.com/couchbase-operator-admission/tls-cert-file"
-          - "--tls-private-key-file"
-          - "/var/run/secrets/couchbase.com/couchbase-operator-admission/tls-private-key-file"
-          {{- range $key, $value := .Values.admissionController.commandArgs }}
-          - "--{{ $key }}={{ $value }}"
-          {{- end }}
-        ports:
-        - name: https
-          containerPort: {{ .Values.admissionService.port }}
-        resources:
-{{ toYaml .Values.admissionController.resources | indent 12 }}
-        volumeMounts:
-        - name: couchbase-operator-admission
-          mountPath: "/var/run/secrets/couchbase.com/couchbase-operator-admission"
-          readOnly: true
 ---
 apiVersion: v1
 kind: Service

--- a/charts/couchbase-operator/tests/admission-deployment_test.yaml
+++ b/charts/couchbase-operator/tests/admission-deployment_test.yaml
@@ -1,0 +1,87 @@
+suite: test admission-controller deployment
+templates:
+  - admission-deployment.yaml
+tests:
+  - it: should be a Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+  - it: should override chart name
+    set:
+      admissionController:
+        name: my-magellan
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-my-magellan
+  - it: should set Deployment name
+    set:
+      admissionController:
+        name: smooth-operator
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-smooth-operator
+  - it: should have default service account name
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-couchbase-admission-controller
+  - it: should set service account name to operator name
+    set:
+      admissionController:
+        name: different-name
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-different-name
+  - it: should have default image
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "couchbase/admission-controller:\\d+?"
+  - it: should set image repository and tag
+    set:
+      admissionController:
+        image:
+          repository: myrepo/operator
+          tag: 9.11.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "myrepo/operator:9.11.0"
+  - it: should set pullPolicy to 'Always'
+    set:
+      admissionController:
+        imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should not have default pull secrets
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+  - it: should set custom pull secrets
+    set:
+      admissionController:
+        imagePullSecrets:
+          - topsecret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: topsecret
+  - it: should have Deployment secret
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: RELEASE-NAME-couchbase-admission-controller
+  - it: should set custom Deployment secret
+    set:
+      admissionSecret:
+        name: topsecret
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].secret.secretName
+          value: topsecret

--- a/charts/couchbase-operator/tests/operator-deployment_test.yaml
+++ b/charts/couchbase-operator/tests/operator-deployment_test.yaml
@@ -1,0 +1,104 @@
+suite: test operator-deployment
+templates:
+  - operator-deployment.yaml
+tests:
+  - it: should be a Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+  - it: should set Deployment name
+    set:
+      couchbaseOperator:
+        name: smooth-operator
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-smooth-operator
+  - it: should have default service account name
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-couchbase-operator
+  - it: should have same service account name as operator name
+    set:
+      couchbaseOperator:
+        name: different-name
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-different-name
+  - it: should have default image
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "couchbase/operator:\\d+?.\\d+?.\\d+?"
+  - it: should set image repository and tag
+    set:
+      couchbaseOperator:
+        image:
+          repository: myrepo/operator
+          tag: 9.11.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "myrepo/operator:9.11.0"
+  - it: should set pullPolicy to 'Always'
+    set:
+      couchbaseOperator:
+        imagePullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: should not have default pull secrets
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+  - it: should set custom pull secrets
+    set:
+      couchbaseOperator:
+        imagePullSecrets:
+          - topsecret
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: topsecret
+  - it: should have command args for pod-timeout 
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: "--pod-create-timeout=10m"
+  - it: should remove command args
+    set:
+      couchbaseOperator:
+        commandArgs: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - couchbase-operator
+  - it: should set tolerations
+    set:
+      couchbaseOperator:
+        nodeSelector:
+          zone: us-east1-a
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+              zone: us-east1-a
+  - it: should set node selectors
+    set:
+      couchbaseOperator:
+        tolerations:
+          - key: "key"
+            operator: "Exists"
+            effect: "NoSchedule"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0]
+          value:
+            key: "key"
+            operator: "Exists"
+            effect: "NoSchedule"


### PR DESCRIPTION
The DAC template is slightly re-arranged so that the Deployment
resource is the first object to be tested, rather than having
to use documentIndex for each test:
https://github.com/vbehar/helm3-unittest/blob/master/DOCUMENT.md#assertion