### PR TITLE
K8S-2338: Resolve issue with backup & restore

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -6,7 +6,14 @@ name: Publish CI
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - main
+    # Ignore anything unrelated to a chart release
+    paths-ignore:
+      - 'charts/couchbase-operator/examples/**'
+      - 'assets/**'
+      - 'tools/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/validate-ci.yml
+++ b/.github/workflows/validate-ci.yml
@@ -4,7 +4,9 @@ name: Validate CI
 # Controls when the workflow will run
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+    - master
+    - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/validate-ci.yml
+++ b/.github/workflows/validate-ci.yml
@@ -5,8 +5,13 @@ name: Validate CI
 on:
   pull_request:
     branches:
-    - master
-    - main
+      - master
+      - main
+    # Ignore anything unrelated to a chart release
+    paths-ignore:
+      - 'charts/couchbase-operator/examples/**'
+      - 'assets/**'
+      - 'tools/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/charts/couchbase-operator/Chart.yaml
+++ b/charts/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.2.101
+version: 2.2.102
 appVersion: 2.2.1
 type: application
 keywords:

--- a/charts/couchbase-operator/templates/couchbase-backup.yaml
+++ b/charts/couchbase-operator/templates/couchbase-backup.yaml
@@ -74,7 +74,7 @@ items:
     labels:
       cluster: {{ include "couchbase-cluster.clustername" $rootScope }}
   spec:
-{{ toYaml $spec | indent 4 }}
+{{ omit $spec "name" | toYaml | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/couchbase-operator/templates/couchbase-backup.yaml
+++ b/charts/couchbase-operator/templates/couchbase-backup.yaml
@@ -93,7 +93,7 @@ items:
     labels:
       cluster: {{ include "couchbase-cluster.clustername" $rootScope }}
   spec:
-{{ toYaml $spec | indent 4 }}
+{{ omit $spec "name" | toYaml | indent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/couchbase-operator/templates/couchbase-bucket.yaml
+++ b/charts/couchbase-operator/templates/couchbase-bucket.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: List
 metadata:
-  name: {{ printf "%s-buckets" (include "couchbase-cluster.clustername" .) }} 
+  name: {{ printf "%s-buckets" (include "couchbase-cluster.clustername" .) }}
 items:
 {{- range $bucket, $spec := .Values.buckets }}
 {{- if typeIs "map[string]interface {}" $spec }}

--- a/charts/couchbase-operator/values.yaml
+++ b/charts/couchbase-operator/values.yaml
@@ -126,7 +126,7 @@ backups: {}
 #       schedule: "0 3 * * 1-6"
 #     successfulJobsHistoryLimit: 1
 #     failedJobsHistoryLimit: 3
-#     backOffLimit: 2
+#     backoffLimit: 2
 #     backupRetention: 24h
 #     logRetention: 24h
 #     size: 5Gi
@@ -146,7 +146,7 @@ backuprestores: {}
 #   end:
 #     int: 1
 #     str: latest
-#   backOffLimit: 2
+#   backoffLimit: 2
 #   logRetention: 24h
 
 # RBAC users to create

--- a/charts/couchbase-operator/values.yaml
+++ b/charts/couchbase-operator/values.yaml
@@ -136,18 +136,19 @@ backuprestores: {}
 #
 # Uncomment to create a restore named 'my-restore'
 #
-# default-restore:
-#   name: my-restore
-#   backup: my-backup
-#   repo: cb-example-2020-11-12T19_00_03
-#   start:
-#     int: 1
-#     str: oldest
-#   end:
-#     int: 1
-#     str: latest
-#   backoffLimit: 2
-#   logRetention: 24h
+#   default-restore:
+#     name: my-restore
+#     backup: my-backup
+#     repo: cb-example-2020-11-12T19_00_03
+#     start:
+#     # Pick either int or str
+#       # int: 1
+#       str: oldest
+#     end:
+#       # int: 1
+#       str: latest
+#     backoffLimit: 2
+#     logRetention: 24h
 
 # RBAC users to create
 # (requires couchbase server 6.5.0 and higher)
@@ -155,18 +156,18 @@ users: {}
 #
 # Uncomment to create an example user named 'developer'
 #
-# developer:
-#   # password to use for user authentication
-#   # (alternatively use authSecret)
-#   password: password
-#   # optional secret to use containing user password
-#   authSecret:
-#   # domain of user authentication
-#   authDomain: local
-#   # roles attributed to group
-#   roles:
-#     - name: bucket_admin
-#       bucket: default
+#   developer:
+#     # password to use for user authentication
+#     # (alternatively use authSecret)
+#     password: password
+#     # optional secret to use containing user password
+#     authSecret:
+#     # domain of user authentication
+#     authDomain: local
+#     # roles attributed to group
+#     roles:
+#       - name: bucket_admin
+#         bucket: default
 
 # TLS Certs that will be used to encrypt traffic between operator and couchbase
 tls:


### PR DESCRIPTION
Resolving issues with examples provided for backup & restore - case incorrect in `backoffLimit`.
Now CRDs are not beta, strict validation is required so also have to filter out `name` field in the spec for backup & restore.
Updated github actions as well to ignore changes outside of the actual chart release - prevents requiring a new helm chart if we just add some examples.