### PR TITLE
K8S-2421: Fix duplicate commandArgs key

### DIFF
--- a/charts/couchbase-operator/templates/operator-deployment.yaml
+++ b/charts/couchbase-operator/templates/operator-deployment.yaml
@@ -30,9 +30,11 @@ spec:
         imagePullPolicy: {{ .Values.couchbaseOperator.imagePullPolicy}}
         command:
         - couchbase-operator
-  {{- range $key, $value := .Values.couchbaseOperator.commandArgs }}
+  {{- if .Values.couchbaseOperator.commandArgs }}
         args:
+  {{- range $key, $value := .Values.couchbaseOperator.commandArgs }}
         - "--{{ $key }}={{ $value }}"
+  {{- end }}
   {{- end }}
         env:
         - name: WATCH_NAMESPACE


### PR DESCRIPTION
Addresses issue where multiple args being specified causes command arg key is repeated.