### PR TITLE
sync-gateway: Add pod annotations

### DIFF
--- a/charts/couchbase-operator/Chart.yaml
+++ b/charts/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.2.301
+version: 2.2.302
 appVersion: 2.2.3
 type: application
 keywords:

--- a/charts/couchbase-operator/templates/sync-gateway-deployment.yaml
+++ b/charts/couchbase-operator/templates/sync-gateway-deployment.yaml
@@ -23,6 +23,10 @@ spec:
 
   template:
     metadata:
+      {{- with .Values.syncGateway.podAnnotations }}
+      annotations:        
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- with .Values.syncGateway.podLabels }}
         {{- toYaml . | nindent 8 }}

--- a/charts/couchbase-operator/values.yaml
+++ b/charts/couchbase-operator/values.yaml
@@ -195,6 +195,8 @@ syncGateway:
   revisionHistoryLimit:
   # -- labels to apply to the deployment resource
   labels: {}
+  # -- Annotations to apply to the pods
+  podAnnotations: {}
   # -- labels to apply to the pods
   podLabels: {}
   # -- resources to apply to the pods


### PR DESCRIPTION
This is useful for configuring things like Datadog autodiscovery for
monitoring:

  syncGateway:
    podAnnotations:
      ad.datadoghq.com/sync-gateway.check_names: '[ "couchbase" ]'
      ad.datadoghq.com/sync-gateway.init_configs: '[{}]'
      ad.datadoghq.com/sync-gateway.instances: |
        [
          {
            "server": "http://server:8091",
            "sync_gateway_url": "http://%%host%%:4986",
            "user":"%%env_DD_COUCHBASE_USERNAME%%",
            "password":"%%env_DD_COUCHBASE_PASSWORD%%",
          }
        ]