### PR TITLE
K8S-2750: check tls.secretSource for custom certs

### DIFF
--- a/charts/couchbase-operator/Chart.yaml
+++ b/charts/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.3.001
+version: 2.3.002
 appVersion: 2.3.0
 type: application
 keywords:

--- a/charts/couchbase-operator/templates/_helpers.tpl
+++ b/charts/couchbase-operator/templates/_helpers.tpl
@@ -350,22 +350,36 @@ Get nodeToNodeEncryption value
 {{- end -}}
 
 {{/*
-Name of tls operator secret
+Get or generate name of tls operator secret
 */}}
 {{- define  "couchbase-cluster.tls.operator-secret" -}}
 {{- if .Values.cluster.networking.tls -}}
-{{- .Values.cluster.networking.tls.static.operatorSecret -}}
+
+  {{/* secret may be legacy or native format */}}
+  {{- if (include "couchbase-cluster.tls.is-legacy" .) -}}
+    {{- .Values.cluster.networking.tls.static.operatorSecret -}}
+  {{- else -}}
+    {{- .Values.cluster.networking.tls.secretSource.clientSecretName -}}
+  {{- end -}}
+
 {{- else -}}
 {{- (printf "%s-operator-tls" (include "couchbase-cluster.fullname" .)) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Name of tls server secret
+Get or generate name of tls server secret
 */}}
 {{- define  "couchbase-cluster.tls.server-secret" -}}
 {{- if .Values.cluster.networking.tls -}}
-{{- .Values.cluster.networking.tls.static.serverSecret -}}
+
+  {{/* secret may be legacy or native format */}}
+  {{- if (include "couchbase-cluster.tls.is-legacy" .) -}}
+    {{- .Values.cluster.networking.tls.static.serverSecret -}}
+  {{- else -}}
+    {{- .Values.cluster.networking.tls.secretSource.serverSecretName -}}
+  {{- end -}}
+
 {{- else -}}
 {{- (printf "%s-server-tls" (include "couchbase-cluster.fullname" .)) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}


### PR DESCRIPTION
When user provides their own TLS Certificates , then the helm chart defaults to checking tls.static for location of the secrets.  This is a problem because the secrets may be provided via tls.secretSource as well.