### PR TITLE
Fix legacy tls detection

### DIFF
--- a/charts/couchbase-operator/Chart.yaml
+++ b/charts/couchbase-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: couchbase-operator
 description: A Helm chart to deploy the Couchbase Autonomous Operator for easily deploying, managing, and maintaining Couchbase Clusters. Couchbase Server is a NoSQL document database with a distributed architecture for performance, scalability, and availability. It enables developers to build applications easier and faster by leveraging the power of SQL with the flexibility of JSON.
-version: 2.32.0
+version: 2.32.1
 appVersion: 2.3.2
 type: application
 keywords:

--- a/charts/couchbase-operator/templates/_helpers.tpl
+++ b/charts/couchbase-operator/templates/_helpers.tpl
@@ -294,7 +294,7 @@ Determine if tls legacy mode is enabled.  Legacy TLS involves use of static secr
     {{- $clusterName := (include "couchbase-cluster.clustername" .) -}}
     {{- $clusterSpec := (lookup "couchbase.com/v2" "CouchbaseCluster" .Release.Namespace $clusterName) -}}
     {{- if $clusterSpec -}}
-      {{- $clusterTLS := $clusterSpec.spec.networking -}}
+      {{- $clusterTLS := $clusterSpec.spec.networking.tls -}}
       {{- if $clusterTLS -}}
         {{- if $clusterTLS.static -}}
           {{/* legacy format is in use for cluster  */}}


### PR DESCRIPTION
When cluster is using legacy tls the upgrade fails when cluster name is also explicitely overriden because helm wasn't using the full tls lookup path.